### PR TITLE
Propagating trailers in StatusRuntimeException

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'grpcbridge'
 archivesBaseName = 'grpcbridge'
-version = '1.0.10'
+version = '1.0.11'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/lib/src/main/java/grpcbridge/rpc/AsyncCall.java
+++ b/lib/src/main/java/grpcbridge/rpc/AsyncCall.java
@@ -37,7 +37,7 @@ final class AsyncCall extends ServerCall<Message, Message> {
     @Override
     public void close(Status status, Metadata trailers) {
         if (!status.isOk()) {
-            delegate.setException(new StatusRuntimeException(status));
+            delegate.setException(new StatusRuntimeException(status, trailers));
         }
     }
 

--- a/lib/src/test/java/grpcbridge/common/TestFactory.java
+++ b/lib/src/test/java/grpcbridge/common/TestFactory.java
@@ -7,6 +7,7 @@ import grpcbridge.test.proto.Test.DeleteRequest;
 import grpcbridge.test.proto.Test.DeleteResponse;
 import grpcbridge.test.proto.Test.GetRequest;
 import grpcbridge.test.proto.Test.GetResponse;
+import grpcbridge.test.proto.Test.GrpcErrorRequest;
 import grpcbridge.test.proto.Test.Nested;
 import grpcbridge.test.proto.Test.PatchRequest;
 import grpcbridge.test.proto.Test.PatchResponse;
@@ -94,6 +95,12 @@ public final class TestFactory {
     public static PatchResponse responseFor(PatchRequest request) {
         return PatchResponse.newBuilder()
                 .setStringField(request.getStringField())
+                .build();
+    }
+
+    public static GrpcErrorRequest newGrpcErrorRequest(boolean addMetadata) {
+        return GrpcErrorRequest.newBuilder()
+                .setAddMetadata(addMetadata)
                 .build();
     }
 }

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -1,10 +1,15 @@
 package grpcbridge.common;
 
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static io.grpc.Status.FAILED_PRECONDITION;
+
 import com.google.protobuf.TextFormat;
 import grpcbridge.test.proto.Test.DeleteRequest;
 import grpcbridge.test.proto.Test.DeleteResponse;
 import grpcbridge.test.proto.Test.GetRequest;
 import grpcbridge.test.proto.Test.GetResponse;
+import grpcbridge.test.proto.Test.GrpcErrorRequest;
+import grpcbridge.test.proto.Test.GrpcErrorResponse;
 import grpcbridge.test.proto.Test.PatchRequest;
 import grpcbridge.test.proto.Test.PatchResponse;
 import grpcbridge.test.proto.Test.PostRequest;
@@ -12,6 +17,8 @@ import grpcbridge.test.proto.Test.PostResponse;
 import grpcbridge.test.proto.Test.PutRequest;
 import grpcbridge.test.proto.Test.PutResponse;
 import grpcbridge.test.proto.TestServiceGrpc;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import org.slf4j.Logger;
@@ -135,5 +142,19 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
                 .setStringField(request.getStringField())
                 .build());
         responseObserver.onCompleted();
+    }
+
+    @Override
+    public void grpcError(
+            GrpcErrorRequest request,
+            StreamObserver<GrpcErrorResponse> responseObserver) {
+        Metadata trailers = null;
+        if (request.getAddMetadata()) {
+            trailers = new Metadata();
+            trailers.put(Metadata.Key.of("error-details", ASCII_STRING_MARSHALLER), "grpc error");
+        }
+        throw new StatusRuntimeException(
+                FAILED_PRECONDITION.withDescription("Expected GRPC error"),
+                trailers);
     }
 }

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -69,6 +69,13 @@ message PatchResponse {
   string string_field = 1;
 }
 
+message GrpcErrorRequest {
+  bool add_metadata = 1;
+}
+
+message GrpcErrorResponse {
+}
+
 
 service TestService {
   rpc Get (GetRequest) returns (GetResponse) {
@@ -155,6 +162,12 @@ service TestService {
   rpc Patch (PatchRequest) returns (PatchResponse) {
     option (google.api.http) = {
         patch: "/patch/{string_field}"
+    };
+  }
+
+  rpc GrpcError (GrpcErrorRequest) returns (GrpcErrorResponse) {
+    option (google.api.http) = {
+        get: "/grpc-error?add_metadata={add_metadata}"
     };
   }
 }


### PR DESCRIPTION
Metadata trailers are not proxied into StatusRuntimeException. Fixing and adding tests.