### PR TITLE
reserve plus sign during url decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maven:
 
 Gradle:
 ```groovy
-compile 'grpcbridge:grpcbridge:1.0.14'
+compile 'grpcbridge:grpcbridge:1.0.15'
 ```
 
 The library requires Java 8.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'grpcbridge'
 archivesBaseName = 'grpcbridge'
-version = '1.0.14'
+version = '1.0.15'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
+++ b/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
@@ -1,5 +1,6 @@
 package grpcbridge.route;
 
+import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
@@ -64,7 +65,8 @@ final class UrlPathAndQuery {
                     ? new SimpleImmutableEntry<>(keyAndValue[0], singletonList(""))
                     : new SimpleImmutableEntry<>(
                             keyAndValue[0],
-                            singletonList(URLDecoder.decode(keyAndValue[1], UTF_8.name())));
+                            singletonList(URLDecoder.decode(urlFormParameterEscaper()
+                                    .escape(keyAndValue[1]), UTF_8.name())));
         } catch (UnsupportedEncodingException ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
The Java.net.URLDecoder treats `+` as a special case and convert it to space.
https://docs.oracle.com/javase/8/docs/api/java/net/URLDecoder.html

This is breaks the call: `https://api.dev.token.io/resolve-alias?value=y+nv@t.io&type=EMAIL`, since our sdk doesn't url encode the parameters. We will start encoding parameters, but to keep old sdk compatible we have to handle the plus sign manually here.