### PR TITLE
Use PercentEscaper to url encode unsafe characters before decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maven:
 
 Gradle:
 ```groovy
-compile 'grpcbridge:grpcbridge:1.0.15'
+compile 'grpcbridge:grpcbridge:1.0.16'
 ```
 
 The library requires Java 8.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'grpcbridge'
 archivesBaseName = 'grpcbridge'
-version = '1.0.15'
+version = '1.0.16'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
+++ b/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
@@ -1,9 +1,10 @@
 package grpcbridge.route;
 
-import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
+
+import com.google.common.net.PercentEscaper;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -65,8 +66,9 @@ final class UrlPathAndQuery {
                     ? new SimpleImmutableEntry<>(keyAndValue[0], singletonList(""))
                     : new SimpleImmutableEntry<>(
                             keyAndValue[0],
-                            singletonList(URLDecoder.decode(urlFormParameterEscaper()
-                                    .escape(keyAndValue[1]), UTF_8.name())));
+                            singletonList(URLDecoder.decode(
+                                    new PercentEscaper("%", false).escape(keyAndValue[1]),
+                                    UTF_8.name())));
         } catch (UnsupportedEncodingException ex) {
             throw new RuntimeException(ex);
         }

--- a/lib/src/test/java/grpcbridge/route/UrlPathAndQueryTest.java
+++ b/lib/src/test/java/grpcbridge/route/UrlPathAndQueryTest.java
@@ -51,6 +51,21 @@ public class UrlPathAndQueryTest {
     }
 
     @Test
+    public void paramWithValue_URLEncoded() {
+        UrlPathAndQuery pathAndQuery = UrlPathAndQuery
+                .parse("/simple?p1={%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E}");
+        assertThat(pathAndQuery.path()).isEqualTo("/simple");
+        assertThat(pathAndQuery.query()).containsEntry("p1", list("{ \"%-.<>\\^_`{|}~}"));
+    }
+
+    @Test
+    public void paramWithValue_reservedCharacters() {
+        UrlPathAndQuery pathAndQuery = UrlPathAndQuery.parse("/simple?p1={!*'();:@+$,/#[]}");
+        assertThat(pathAndQuery.path()).isEqualTo("/simple");
+        assertThat(pathAndQuery.query()).containsEntry("p1", list("{!*'();:@+$,/#[]}"));
+    }
+
+    @Test
     public void multipleParams() {
         UrlPathAndQuery pathAndQuery = UrlPathAndQuery.parse("/simple?p1={pp1}&p2={pp2}&p3={pp3}");
         assertThat(pathAndQuery.path()).isEqualTo("/simple");


### PR DESCRIPTION
The `PercentEscaper` will keep safe characters unescaped. By setting the safe char to be `%`, the `PercentEscaper` will only encode the part of the string that hasn't been url encoded(an encoded character would look like `%XY`).