### PR TITLE
 Adding support for the bridge to send the RPC call to a different gR…

### DIFF
--- a/lib/src/main/java/grpcbridge/BridgeBuilder.java
+++ b/lib/src/main/java/grpcbridge/BridgeBuilder.java
@@ -1,14 +1,16 @@
 package grpcbridge;
 
-import com.google.protobuf.Descriptors.FileDescriptor;
-import com.google.protobuf.Message;
-import io.grpc.ServerMethodDefinition;
-import io.grpc.ServerServiceDefinition;
-import grpcbridge.route.Route;
-import grpcbridge.util.FileDescriptors;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Message;
+
+import grpcbridge.route.Route;
+import grpcbridge.util.FileDescriptors;
+import io.grpc.Channel;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
 
 /**
  * Used to build {@link Bridge} instances. When a protobuf file is compiled
@@ -23,6 +25,7 @@ import java.util.List;
 public final class BridgeBuilder {
     private final FileDescriptors files = new FileDescriptors();
     private final List<ServerServiceDefinition> services = new ArrayList<>();
+    private Channel forwardChannel = null;
 
     /**
      * Adds protobuf file descriptor. Call this method for each of the protobuf
@@ -49,6 +52,17 @@ public final class BridgeBuilder {
     }
 
     /**
+     * Sets a channel to forward the resulting gRPC call to. If this is not set, then the 
+     * call is handled within the same server.
+     * @param forwardChannel
+     * @return
+     */
+    public BridgeBuilder setForwardChannel(Channel forwardChannel) {
+        this.forwardChannel = forwardChannel;
+        return this;
+    }
+
+    /**
      * Creates new instance of the {@link Bridge}.
      *
      * @return built bride instance
@@ -66,6 +80,11 @@ public final class BridgeBuilder {
             }
         }
 
-        return new Bridge(routes);
+        Bridge bridge = new Bridge(routes);
+        if (forwardChannel != null) {
+            bridge.setForwardChannel(forwardChannel);
+        }
+        
+        return bridge;
     }
 }

--- a/lib/src/main/java/grpcbridge/route/PathMatcher.java
+++ b/lib/src/main/java/grpcbridge/route/PathMatcher.java
@@ -13,7 +13,7 @@ final class PathMatcher {
     private final VariableExtractor path;
 
     public PathMatcher(HttpRule httpRule) {
-        String path;
+        String path = null;
         if (!httpRule.getGet().isEmpty()) {
             this.method = HttpMethod.GET;
             path = httpRule.getGet();
@@ -30,16 +30,23 @@ final class PathMatcher {
             this.method = HttpMethod.PATCH;
             path = httpRule.getPatch();
         } else {
-            throw new UnsupportedOperationException("Unsupported method: " + httpRule);
+            // just ignore RPCs that have no valid HttpRule
+            this.method = null;
         }
-        this.path = new VariableExtractor(path);
+        this.path = path == null ? null : new VariableExtractor(path);
     }
 
     public boolean matches(HttpRequest httpRequest) {
+        if ((method == null) || (path == null)) {
+            return false;
+        }
         return method == httpRequest.getMethod() && path.matches(httpRequest.getPath());
     }
 
     public List<Variable> parse(HttpRequest httpRequest) {
+        if ((method == null) || (path == null)) {
+            return null;
+        }
         return path.extract(httpRequest.getPath());
     }
 

--- a/lib/src/main/java/grpcbridge/rpc/RpcCall.java
+++ b/lib/src/main/java/grpcbridge/rpc/RpcCall.java
@@ -44,4 +44,14 @@ public final class RpcCall {
 
         return result;
     }
+
+    public RpcMessage getRequest() {
+        return request;
+    }
+
+    public ServerMethodDefinition<Message, Message> getMethod() {
+        return method;
+    }
+    
+    
 }

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -160,8 +160,8 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
             trailers = new Metadata();
             trailers.put(Metadata.Key.of("error-details", ASCII_STRING_MARSHALLER), "grpc error");
         }
-        throw new StatusRuntimeException(
+        responseObserver.onError(new StatusRuntimeException(
                 FAILED_PRECONDITION.withDescription("Expected GRPC error"),
-                trailers);
+                trailers));
     }
 }


### PR DESCRIPTION
Adding support for the bridge to send the RPC call to a different gRPC server instead of invoking the service directly.

Hello @akalini ,
So our use case was we had a grpc server where we wanted a few rpc calls exposed in http as well. I was able to use your library to get most of the way, however the problem was none of the gRPC Interceptors (like our auth checking) was invoked for the http endpoints.
This pull request is to have a mode on the Bridge, so instead of calling grpc services directly from the http server, instead it proxies them through a grpc channel of another running server. (Could be running in the same process or remote)
Let me know what you think, if this works or if there are any other changes to get this merged.
Thanks!