### PR TITLE
Adding support for stream responses

### DIFF
--- a/lib/src/main/java/grpcbridge/rpc/RpcCall.java
+++ b/lib/src/main/java/grpcbridge/rpc/RpcCall.java
@@ -38,8 +38,9 @@ public final class RpcCall {
                 .startCall(
                         new AsyncCall(method.getMethodDescriptor(), result),
                         request.getMetadata());
-
-        listener.onMessage(request.getBody());
+        for (Message message : request.getBody()) {
+            listener.onMessage(message);
+        }
         listener.onHalfClose();
 
         return result;

--- a/lib/src/main/java/grpcbridge/util/ProtoJson.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoJson.java
@@ -67,17 +67,17 @@ public final class ProtoJson {
     }
 
     public static HttpResponse serialize(RpcMessage message) {
-        String httpBody;
         if (message.getMethodType().serverSendsOneMessage()) {
-            httpBody = !message.getBody().isEmpty() ? serialize(message.getBody().get(0)) : "";
+            String httpBody = !message.getBody().isEmpty() ? serialize(message.getBody().get(0)) : "";
+            return new HttpResponse(httpBody, message.getMetadata());
         } else {
-            List<String> messagesBody = new ArrayList<String>();
-            for (Message msg : message.getBody()) {
-                messagesBody.add(serialize(msg));
+            StringBuilder builder = new StringBuilder("[");
+            for (int i = 0; i < message.getBody().size(); i++) {
+                builder.append((i > 0 ? "," : "") + serialize(message.getBody().get(i)));
             }
-            httpBody = "[" + Joiner.on(",").join(messagesBody) + "]";
+            builder.append("]");
+            return new HttpResponse(builder.toString(), message.getMetadata());
         }
-        return new HttpResponse(httpBody, message.getMetadata());
     }
 
     public static String serialize(Message message) {

--- a/lib/src/main/java/grpcbridge/util/ProtoJson.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoJson.java
@@ -2,16 +2,23 @@ package grpcbridge.util;
 
 import static java.lang.String.format;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.gson.Gson;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
+
 import grpcbridge.Exceptions.ParsingException;
 import grpcbridge.http.HttpRequest;
 import grpcbridge.http.HttpResponse;
 import grpcbridge.rpc.RpcMessage;
-
-import javax.annotation.Nullable;
 
 /**
  * Helper methods to convert from JSON to protobuf messages and back.
@@ -29,6 +36,24 @@ public final class ProtoJson {
         return new RpcMessage(parse(httpResponse.getBody(), builder), httpResponse.getTrailers());
     }
 
+    @SuppressWarnings("rawtypes")
+    public static <T extends Message> List<T> parseStream(@Nullable String body, T.Builder builder) {
+        List<T> messages = new ArrayList<>();
+        if (!Strings.isNullOrEmpty(body)) {
+            /** Parses the containing json which is not gRPC parsable
+             * then splits them into individual json strings for each message so JsonFormat
+             * can be used to parse them */
+            Gson gson = new Gson();
+            Map[] jsonMsgs = gson.fromJson(body, Map[].class);
+            for (Map message : jsonMsgs) {
+                messages.add(parse(gson.toJson(message), builder));
+                builder.clear();
+            }
+        }
+        return messages;
+    }
+    
+
     @SuppressWarnings("unchecked")
     public static <T extends Message> T parse(@Nullable String body, T.Builder builder) {
         if (!Strings.isNullOrEmpty(body)) {
@@ -42,8 +67,17 @@ public final class ProtoJson {
     }
 
     public static HttpResponse serialize(RpcMessage message) {
-        String body = serialize(message.getBody());
-        return new HttpResponse(body, message.getMetadata());
+        String httpBody;
+        if (message.getMethodType().serverSendsOneMessage()) {
+            httpBody = !message.getBody().isEmpty() ? serialize(message.getBody().get(0)) : "";
+        } else {
+            List<String> messagesBody = new ArrayList<String>();
+            for (Message msg : message.getBody()) {
+                messagesBody.add(serialize(msg));
+            }
+            httpBody = "[" + Joiner.on(",").join(messagesBody) + "]";
+        }
+        return new HttpResponse(httpBody, message.getMetadata());
     }
 
     public static String serialize(Message message) {

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -14,10 +14,13 @@ import static grpcbridge.http.HttpMethod.POST;
 import static grpcbridge.http.HttpMethod.PUT;
 import static grpcbridge.test.proto.Test.Enum.INVALID;
 import static grpcbridge.util.ProtoJson.parse;
+import static grpcbridge.util.ProtoJson.parseStream;
 import static grpcbridge.util.ProtoJson.serialize;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+
+import java.util.List;
 
 import org.junit.Test;
 
@@ -517,5 +520,23 @@ public class BridgeTest {
                 .toBuilder()
                 .setStringField("hello")
                 .build()));
+    }
+    
+    @Test
+    public void getStream() {
+        GetRequest rpcRequest = newGetRequest();
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get-stream/hello?int_field=2")
+                .body(serialize(rpcRequest))
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        
+        List<GetResponse> responses = parseStream(response.getBody(), GetResponse.newBuilder());
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStringField()).isEqualTo("hello");
+        assertThat(responses.get(0).getIntField()).isEqualTo(0);
+        assertThat(responses.get(1).getStringField()).isEqualTo("hello");
+        assertThat(responses.get(1).getIntField()).isEqualTo(1);
     }
 }

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -164,4 +164,27 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
                 FAILED_PRECONDITION.withDescription("Expected GRPC error"),
                 trailers);
     }
+
+    @Override
+    public void getStream(
+            GetRequest request,
+            StreamObserver<GetResponse> responseObserver) {
+        
+        logger.info("Get({})", TextFormat.shortDebugString(request));
+        for (int i = 0; i < request.getIntField(); i++) {
+            responseObserver.onNext(GetResponse.newBuilder()
+                    .setStringField(request.getStringField())
+                    .setIntField(i)
+                    .setLongField(request.getLongField())
+                    .setFloatField(request.getFloatField())
+                    .setDoubleField(request.getDoubleField())
+                    .setBoolField(request.getBoolField())
+                    .setEnumField(request.getEnumField())
+                    .setBytesField(request.getBytesField())
+                    .setNested(request.getNested())
+                    .addAllRepeatedField(request.getRepeatedFieldList())
+                    .build());
+        }
+        responseObserver.onCompleted();
+    }
 }

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -176,4 +176,10 @@ service TestService {
         get: "/grpc-error?add_metadata={add_metadata}"
     };
   }
+  
+  rpc GetStream (GetRequest) returns (stream GetResponse) {
+    option (google.api.http) = {
+        get: "/get-stream/{string_field}?int_field={int_field}"
+    };
+  }
 }


### PR DESCRIPTION
Hi @akalini,
I took a stab at supporting returning a stream of messages.
eg. ```rpc GetStream (GetRequest) returns (stream GetResponse)```

How it works, AsyncCall now collects all messages that come in from sendMessage and then sends all of the messages as an RpcMessage when the call is closed.
Then when the RpcMessage is serialized it checks the MethodDescriptor to see if it is a stream or unary.
If it is a stream then it converts ALL of the messages into json and then wraps them in a json array.
unary will work exactly as it did before.
One thing I wasn't too sure of was parsing the array of messages back into gRPC messages. Didn't seem like an out of the box way from JsonFormat class, so I ended up just using Gson to be able to split the json array into an array holding each of the message's json. However, this isn't used anywhere but the unit tests.

I didn't touch request streaming, really not sure how that would look from an http endpoint.
Let me know if this works for you.