### PR TITLE
Add logic to be able to preserve case

### DIFF
--- a/lib/src/main/java/grpcbridge/BridgeBuilder.java
+++ b/lib/src/main/java/grpcbridge/BridgeBuilder.java
@@ -27,6 +27,7 @@ public final class BridgeBuilder {
     private final FileDescriptors files = new FileDescriptors();
     private final List<ServerServiceDefinition> services = new ArrayList<>();
     private final List<ServerInterceptor> interceptors = new ArrayList<>();
+    private boolean preserveProtoFieldNames = false;
 
     /**
      * Adds protobuf file descriptor. Call this method for each of the protobuf
@@ -63,6 +64,16 @@ public final class BridgeBuilder {
     }
 
     /**
+     * Set whether you want to preserver proto field names
+     * @param preserveProtoFieldNames If set to true it will not convert field names to camelCase
+     * @return this builder instance
+     */
+    public BridgeBuilder preserveProtoFieldNames(boolean preserveProtoFieldNames) {
+        this.preserveProtoFieldNames = preserveProtoFieldNames;
+        return this;
+    }
+
+    /**
      * Creates new instance of the {@link Bridge}.
      *
      * @return built bride instance
@@ -83,6 +94,6 @@ public final class BridgeBuilder {
             }
         }
 
-        return new Bridge(routes);
+        return new Bridge(routes, preserveProtoFieldNames);
     }
 }

--- a/lib/src/main/java/grpcbridge/BridgeBuilder.java
+++ b/lib/src/main/java/grpcbridge/BridgeBuilder.java
@@ -3,6 +3,7 @@ package grpcbridge;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Message;
 
+import com.google.protobuf.util.JsonFormat;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerMethodDefinition;
@@ -27,7 +28,7 @@ public final class BridgeBuilder {
     private final FileDescriptors files = new FileDescriptors();
     private final List<ServerServiceDefinition> services = new ArrayList<>();
     private final List<ServerInterceptor> interceptors = new ArrayList<>();
-    private boolean preserveProtoFieldNames = false;
+    private JsonFormat.Printer printer = JsonFormat.printer();
 
     /**
      * Adds protobuf file descriptor. Call this method for each of the protobuf
@@ -65,12 +66,11 @@ public final class BridgeBuilder {
 
     /**
      * Set whether you want to preserver proto field names
-     * @param preserveProtoFieldNames If set to true it will use the exact field name casing from
-     *                               proto file when serializing to json
+     * @param printer Printer used for serializing to json
      * @return this builder instance
      */
-    public BridgeBuilder preserveProtoFieldNames(boolean preserveProtoFieldNames) {
-        this.preserveProtoFieldNames = preserveProtoFieldNames;
+    public BridgeBuilder printer(JsonFormat.Printer printer) {
+        this.printer = printer;
         return this;
     }
 
@@ -95,6 +95,6 @@ public final class BridgeBuilder {
             }
         }
 
-        return new Bridge(routes, preserveProtoFieldNames);
+        return new Bridge(routes, printer);
     }
 }

--- a/lib/src/main/java/grpcbridge/BridgeBuilder.java
+++ b/lib/src/main/java/grpcbridge/BridgeBuilder.java
@@ -65,7 +65,8 @@ public final class BridgeBuilder {
 
     /**
      * Set whether you want to preserver proto field names
-     * @param preserveProtoFieldNames If set to true it will not convert field names to camelCase
+     * @param preserveProtoFieldNames If set to true it will use the exact field name casing from
+     *                               proto file when serializing to json
      * @return this builder instance
      */
     public BridgeBuilder preserveProtoFieldNames(boolean preserveProtoFieldNames) {

--- a/lib/src/main/java/grpcbridge/util/ProtoJson.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoJson.java
@@ -10,6 +10,7 @@ import grpcbridge.http.HttpRequest;
 import grpcbridge.http.HttpResponse;
 import grpcbridge.rpc.RpcMessage;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,11 +64,11 @@ public final class ProtoJson {
         return (T) builder.build();
     }
 
-    public static HttpResponse serialize(RpcMessage message) {
+    public static HttpResponse serialize(@Nonnull RpcMessage message) {
         return serialize(false, message);
     }
 
-    public static HttpResponse serialize(boolean preserveProtoFieldNames, RpcMessage message) {
+    public static HttpResponse serialize(boolean preserveProtoFieldNames, @Nonnull RpcMessage message) {
         if (message.getMethodType().serverSendsOneMessage()) {
             String httpBody = !message.getBody().isEmpty() ? serialize(preserveProtoFieldNames,
                     message.getBody().get(0))
@@ -84,11 +85,11 @@ public final class ProtoJson {
         }
     }
 
-    public static String serialize(Message message) {
+    public static String serialize(@Nonnull Message message) {
         return serialize(false, message);
     }
 
-    public static String serialize(boolean preserveProtoFieldNames, Message message) {
+    public static String serialize(boolean preserveProtoFieldNames, @Nonnull Message message) {
         try {
             JsonFormat.Printer printer = JsonFormat.printer();
             if (preserveProtoFieldNames) {

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -1,5 +1,24 @@
 package grpcbridge;
 
+import static grpcbridge.common.TestFactory.newDeleteRequest;
+import static grpcbridge.common.TestFactory.newGetRequest;
+import static grpcbridge.common.TestFactory.newGrpcErrorRequest;
+import static grpcbridge.common.TestFactory.newPatchRequest;
+import static grpcbridge.common.TestFactory.newPostRequest;
+import static grpcbridge.common.TestFactory.newPutRequest;
+import static grpcbridge.common.TestFactory.responseFor;
+import static grpcbridge.http.HttpMethod.DELETE;
+import static grpcbridge.http.HttpMethod.GET;
+import static grpcbridge.http.HttpMethod.PATCH;
+import static grpcbridge.http.HttpMethod.POST;
+import static grpcbridge.http.HttpMethod.PUT;
+import static grpcbridge.test.proto.Test.Enum.INVALID;
+import static grpcbridge.util.ProtoJson.parse;
+import static grpcbridge.util.ProtoJson.parseStream;
+import static grpcbridge.util.ProtoJson.serialize;
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import com.google.protobuf.ByteString;
 import grpcbridge.Exceptions.ParsingException;
 import grpcbridge.Exceptions.RouteNotFoundException;
@@ -30,26 +49,6 @@ import io.grpc.StatusRuntimeException;
 import org.junit.Test;
 
 import java.util.List;
-
-import static grpcbridge.common.TestFactory.newDeleteRequest;
-import static grpcbridge.common.TestFactory.newGetRequest;
-import static grpcbridge.common.TestFactory.newGrpcErrorRequest;
-import static grpcbridge.common.TestFactory.newPatchRequest;
-import static grpcbridge.common.TestFactory.newPostRequest;
-import static grpcbridge.common.TestFactory.newPutRequest;
-import static grpcbridge.common.TestFactory.responseFor;
-import static grpcbridge.http.HttpMethod.DELETE;
-import static grpcbridge.http.HttpMethod.GET;
-import static grpcbridge.http.HttpMethod.PATCH;
-import static grpcbridge.http.HttpMethod.POST;
-import static grpcbridge.http.HttpMethod.PUT;
-import static grpcbridge.test.proto.Test.Enum.INVALID;
-import static grpcbridge.util.ProtoJson.parse;
-import static grpcbridge.util.ProtoJson.parseStream;
-import static grpcbridge.util.ProtoJson.serialize;
-import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class BridgeTest {
     private TestService testService = new TestService();

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -1,56 +1,27 @@
 package grpcbridge;
 
-import static grpcbridge.common.TestFactory.newDeleteRequest;
-import static grpcbridge.common.TestFactory.newGetRequest;
-import static grpcbridge.common.TestFactory.newGrpcErrorRequest;
-import static grpcbridge.common.TestFactory.newPatchRequest;
-import static grpcbridge.common.TestFactory.newPostRequest;
-import static grpcbridge.common.TestFactory.newPutRequest;
-import static grpcbridge.common.TestFactory.responseFor;
-import static grpcbridge.http.HttpMethod.DELETE;
-import static grpcbridge.http.HttpMethod.GET;
-import static grpcbridge.http.HttpMethod.PATCH;
-import static grpcbridge.http.HttpMethod.POST;
-import static grpcbridge.http.HttpMethod.PUT;
-import static grpcbridge.test.proto.Test.Enum.INVALID;
-import static grpcbridge.util.ProtoJson.parse;
-import static grpcbridge.util.ProtoJson.parseStream;
-import static grpcbridge.util.ProtoJson.serialize;
-import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
-import java.util.List;
-
-import org.junit.Test;
-
 import com.google.protobuf.ByteString;
 import grpcbridge.Exceptions.ParsingException;
 import grpcbridge.Exceptions.RouteNotFoundException;
 import grpcbridge.common.TestService;
 import grpcbridge.http.HttpRequest;
 import grpcbridge.http.HttpResponse;
-import grpcbridge.test.proto.Test.DeleteRequest;
-import grpcbridge.test.proto.Test.DeleteResponse;
-import grpcbridge.test.proto.Test.GetRequest;
-import grpcbridge.test.proto.Test.GetResponse;
-import grpcbridge.test.proto.Test.GrpcErrorRequest;
-import grpcbridge.test.proto.Test.Nested;
-import grpcbridge.test.proto.Test.PatchRequest;
-import grpcbridge.test.proto.Test.PatchResponse;
-import grpcbridge.test.proto.Test.PostRequest;
-import grpcbridge.test.proto.Test.PostResponse;
-import grpcbridge.test.proto.Test.PutRequest;
-import grpcbridge.test.proto.Test.PutResponse;
-import io.grpc.Metadata;
+import grpcbridge.test.proto.Test.*;
+import io.grpc.*;
 import io.grpc.Metadata.Key;
-import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerInterceptor;
-import io.grpc.Status;
 import io.grpc.Status.Code;
-import io.grpc.StatusRuntimeException;
+import org.junit.Test;
+
+import java.util.List;
+
+import static grpcbridge.common.TestFactory.*;
+import static grpcbridge.http.HttpMethod.*;
+import static grpcbridge.test.proto.Test.Enum.INVALID;
+import static grpcbridge.util.ProtoJson.*;
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class BridgeTest {
     private TestService testService = new TestService();

--- a/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
+++ b/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
@@ -1,0 +1,46 @@
+package grpcbridge;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import grpcbridge.common.TestSnakeService;
+import grpcbridge.http.HttpRequest;
+import grpcbridge.http.HttpResponse;
+import grpcbridge.test.proto.TestSnakeCase;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static grpcbridge.http.HttpMethod.POST;
+import static grpcbridge.util.ProtoJson.parse;
+import static grpcbridge.util.ProtoJson.serialize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SnakeCaseBridgeTest {
+    private TestSnakeService testService = new TestSnakeService();
+    private Bridge bridge = Bridge
+            .builder()
+            .preserveProtoFieldNames(true)
+            .addFile(grpcbridge.test.proto.TestSnakeCase.getDescriptor())
+            .addService(testService.bindService())
+            .build();
+
+    @Test
+    public void preserveSnakeCaseTest() {
+        TestSnakeCase.SnakeRequest rpcRequest = TestSnakeCase.SnakeRequest.newBuilder()
+                .setFirstName("John")
+                .setLastName("Doe").build();
+        HttpRequest request = HttpRequest
+                .builder(POST, "/snake/")
+                .body(serialize(rpcRequest))
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        String raw = response.getBody();
+        Type type = new TypeToken<Map<String, String>>(){}.getType();
+        Map<String, String> json = new Gson().fromJson(raw, type);
+        assertThat(json.get("status_code")).isEqualTo("OK");
+        TestSnakeCase.SnakeResponse rpcResponse = parse(raw, TestSnakeCase.SnakeResponse.newBuilder());
+        assertThat(rpcResponse.getStatusCode()).isEqualTo("OK");
+    }
+}

--- a/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
+++ b/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SnakeCaseBridgeTest {
     private TestSnakeService testService = new TestSnakeService();
-    final JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
+    private final JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
     private Bridge bridge = Bridge
             .builder()
             .printer(printer)

--- a/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
+++ b/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
@@ -2,6 +2,7 @@ package grpcbridge;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.google.protobuf.util.JsonFormat;
 import grpcbridge.common.TestSnakeService;
 import grpcbridge.http.HttpRequest;
 import grpcbridge.http.HttpResponse;
@@ -18,9 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SnakeCaseBridgeTest {
     private TestSnakeService testService = new TestSnakeService();
+    final JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
     private Bridge bridge = Bridge
             .builder()
-            .preserveProtoFieldNames(true)
+            .printer(printer)
             .addFile(grpcbridge.test.proto.TestSnakeCase.getDescriptor())
             .addService(testService.bindService())
             .build();
@@ -32,7 +34,7 @@ public class SnakeCaseBridgeTest {
         TestSnakeCase.SnakeRequest rpcRequest = TestSnakeCase.SnakeRequest.newBuilder()
                 .setFirstName("John")
                 .setLastName("Doe").build();
-        String rawBody = serialize(true, rpcRequest);
+        String rawBody = serialize(printer, rpcRequest);
         Map<String, String> bodyJson = gson.fromJson(rawBody, type);
         assertThat(bodyJson.get("first_name")).isEqualTo("John");
         assertThat(bodyJson.get("last_name")).isEqualTo("Doe");

--- a/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
+++ b/lib/src/test/java/grpcbridge/SnakeCaseBridgeTest.java
@@ -27,17 +27,23 @@ public class SnakeCaseBridgeTest {
 
     @Test
     public void preserveSnakeCaseTest() {
+        final Type type = new TypeToken<Map<String, String>>(){}.getType();
+        final Gson gson = new Gson();
         TestSnakeCase.SnakeRequest rpcRequest = TestSnakeCase.SnakeRequest.newBuilder()
                 .setFirstName("John")
                 .setLastName("Doe").build();
+        String rawBody = serialize(true, rpcRequest);
+        Map<String, String> bodyJson = gson.fromJson(rawBody, type);
+        assertThat(bodyJson.get("first_name")).isEqualTo("John");
+        assertThat(bodyJson.get("last_name")).isEqualTo("Doe");
         HttpRequest request = HttpRequest
                 .builder(POST, "/snake/")
-                .body(serialize(rpcRequest))
+                .body(rawBody)
                 .build();
 
         HttpResponse response = bridge.handle(request);
         String raw = response.getBody();
-        Type type = new TypeToken<Map<String, String>>(){}.getType();
+
         Map<String, String> json = new Gson().fromJson(raw, type);
         assertThat(json.get("status_code")).isEqualTo("OK");
         TestSnakeCase.SnakeResponse rpcResponse = parse(raw, TestSnakeCase.SnakeResponse.newBuilder());

--- a/lib/src/test/java/grpcbridge/common/TestSnakeService.java
+++ b/lib/src/test/java/grpcbridge/common/TestSnakeService.java
@@ -1,0 +1,18 @@
+package grpcbridge.common;
+
+import grpcbridge.test.proto.SnakeTestServiceGrpc;
+import grpcbridge.test.proto.TestSnakeCase;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * Test Implementation for TestSnakeService
+ */
+public class TestSnakeService extends SnakeTestServiceGrpc.SnakeTestServiceImplBase {
+
+    @Override
+    public void snake(TestSnakeCase.SnakeRequest request, StreamObserver<TestSnakeCase.SnakeResponse> responseObserver) {
+        responseObserver.onNext(TestSnakeCase.SnakeResponse.newBuilder().setStatusCode("OK").build
+                ());
+        responseObserver.onCompleted();
+    }
+}

--- a/lib/src/test/java/grpcbridge/common/TestSnakeService.java
+++ b/lib/src/test/java/grpcbridge/common/TestSnakeService.java
@@ -10,9 +10,16 @@ import io.grpc.stub.StreamObserver;
 public class TestSnakeService extends SnakeTestServiceGrpc.SnakeTestServiceImplBase {
 
     @Override
-    public void snake(TestSnakeCase.SnakeRequest request, StreamObserver<TestSnakeCase.SnakeResponse> responseObserver) {
-        responseObserver.onNext(TestSnakeCase.SnakeResponse.newBuilder().setStatusCode("OK").build
-                ());
+    public void snake(
+            TestSnakeCase.SnakeRequest request,
+            StreamObserver<TestSnakeCase.SnakeResponse> responseObserver
+    ) {
+        responseObserver.onNext(
+                TestSnakeCase.SnakeResponse
+                        .newBuilder()
+                        .setStatusCode("OK")
+                        .build()
+        );
         responseObserver.onCompleted();
     }
 }

--- a/lib/src/test/proto/test-snake-case.proto
+++ b/lib/src/test/proto/test-snake-case.proto
@@ -13,11 +13,10 @@ message SnakeResponse {
 }
 
 service SnakeTestService {
-
     rpc snake (SnakeRequest) returns (SnakeResponse) {
         option (google.api.http) = {
-        post: "/snake/"
-        body: "*"
-    };
+            post: "/snake/"
+            body: "*"
+        };
     }
 }

--- a/lib/src/test/proto/test-snake-case.proto
+++ b/lib/src/test/proto/test-snake-case.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package grpcbridge.test.proto;
+
+import "google/api/annotations.proto";
+
+message SnakeRequest {
+    string first_name = 1;
+    string last_name = 2;
+}
+
+message SnakeResponse {
+    string status_code = 1;
+}
+
+service SnakeTestService {
+
+    rpc snake (SnakeRequest) returns (SnakeResponse) {
+        option (google.api.http) = {
+        post: "/snake/"
+        body: "*"
+    };
+    }
+}


### PR DESCRIPTION
In some scenarios you'd want to preserve the case from the proto file, this adds a setting that you can change on the bridge builder to opt in for preserving proto casing.