### PR TITLE
Fix bug where accept could be multiple values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+
+before_cache:
+- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/

--- a/lib/src/main/java/grpcbridge/Bridge.java
+++ b/lib/src/main/java/grpcbridge/Bridge.java
@@ -1,10 +1,6 @@
 package grpcbridge;
 
-import static com.google.common.util.concurrent.Futures.transform;
-import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
-import static grpcbridge.monitoring.Tracer.trace;
-import static java.lang.String.format;
-
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.net.MediaType;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -23,6 +19,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import static com.google.common.util.concurrent.Futures.transform;
+import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
+import static grpcbridge.monitoring.Tracer.trace;
+import static java.lang.String.format;
 
 /**
  * HTTP to gPRC bridge implementation. The bridge is not HTTP library dependent.
@@ -181,7 +182,9 @@ public final class Bridge {
                 "accept",
                 Metadata.ASCII_STRING_MARSHALLER));
         if (acceptedTypes != null) {
-            acceptedTypes.forEach(it -> supportedTypes.add(MediaType.parse(it)));
+            acceptedTypes.forEach(it -> Splitter.on(',').trimResults()
+                    .split(it)
+                    .forEach(type -> supportedTypes.add(MediaType.parse(type))));
         }
         return serializers.stream()
                 .filter(it -> it.supportsAny(supportedTypes))

--- a/lib/src/test/java/grpcbridge/FormDataBridgeTest.java
+++ b/lib/src/test/java/grpcbridge/FormDataBridgeTest.java
@@ -38,6 +38,10 @@ public class FormDataBridgeTest implements ProtoParseTest {
                 Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER),
                 "application/x-www-form-urlencoded; charset=utf-8"
         );
+        headers.put(
+                Metadata.Key.of("accept", Metadata.ASCII_STRING_MARSHALLER),
+                "application/x-www-form-urlencoded, text/xml"
+        );
 
         String rawBody = "first_name=John&last_name=Doe";
 


### PR DESCRIPTION
In some cases `Accept` header could be multiple values. This fix allows for that, for more information see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept#Examples

Added support for Travis builds