### PR TITLE
Support url encoded path variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maven:
 
 Gradle:
 ```groovy
-compile 'grpcbridge:grpcbridge:1.0.16'
+compile 'grpcbridge:grpcbridge:1.0.19'
 ```
 
 The library requires Java 8.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'grpcbridge'
 archivesBaseName = 'grpcbridge'
-version = '1.0.18'
+version = '1.0.19'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava

--- a/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
+++ b/lib/src/main/java/grpcbridge/route/UrlPathAndQuery.java
@@ -59,18 +59,18 @@ final class UrlPathAndQuery {
         return query;
     }
 
+    static String decode(String path) {
+        try {
+            return URLDecoder.decode(new PercentEscaper("%", false).escape(path), UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static Map.Entry<String, List<String>> toMapEntry(String value) {
         String[] keyAndValue = value.split("=");
-        try {
-            return keyAndValue.length == 1
-                    ? new SimpleImmutableEntry<>(keyAndValue[0], singletonList(""))
-                    : new SimpleImmutableEntry<>(
-                            keyAndValue[0],
-                            singletonList(URLDecoder.decode(
-                                    new PercentEscaper("%", false).escape(keyAndValue[1]),
-                                    UTF_8.name())));
-        } catch (UnsupportedEncodingException ex) {
-            throw new RuntimeException(ex);
-        }
+        return keyAndValue.length == 1
+                ? new SimpleImmutableEntry<>(keyAndValue[0], singletonList(""))
+                : new SimpleImmutableEntry<>(keyAndValue[0], singletonList(decode(keyAndValue[1])));
     }
 }

--- a/lib/src/main/java/grpcbridge/route/VariableExtractor.java
+++ b/lib/src/main/java/grpcbridge/route/VariableExtractor.java
@@ -1,5 +1,7 @@
 package grpcbridge.route;
 
+import static grpcbridge.route.UrlPathAndQuery.decode;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -79,7 +81,7 @@ final class VariableExtractor {
         Matcher pathMatcher = pattern.matcher(pathAndQuery.path());
         if (pathMatcher.matches()) {
             for (int i = 0; i < pathVars.size(); i++) {
-                result.add(new Variable(pathVars.get(i), pathMatcher.group(1 + i)));
+                result.add(new Variable(pathVars.get(i), decode(pathMatcher.group(1 + i))));
             }
         }
 

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -61,11 +61,11 @@ public class BridgeTest {
             .addFile(grpcbridge.test.proto.Test.getDescriptor())
             .addService(testService.bindService())
             .build();
-    
+
     private ServerInterceptor authCheck = new ServerInterceptor() {
         @Override
         public <ReqT, RespT> Listener<ReqT> interceptCall(
-                ServerCall<ReqT, RespT> call, 
+                ServerCall<ReqT, RespT> call,
                 Metadata headers,
                 ServerCallHandler<ReqT, RespT> next) {
             if (headers.containsKey(Key.of("auth", Metadata.ASCII_STRING_MARSHALLER))) {
@@ -184,6 +184,24 @@ public class BridgeTest {
     }
 
     @Test
+    public void get_withParams_encoded() {
+        GetRequest rpcRequest = newGetRequest();
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get?string_field=h%3Del%2Fl%26o&int_field=987")
+                .body(serialize(rpcRequest))
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        GetResponse rpcResponse = parse(response.getBody(), GetResponse.newBuilder());
+
+        assertThat(rpcResponse).isEqualTo(responseFor(rpcRequest
+                .toBuilder()
+                .setStringField("h=el/l&o")
+                .setIntField(987)
+                .build()));
+    }
+
+    @Test
     public void get_withParams_noParams() {
         GetRequest rpcRequest = newGetRequest();
         HttpRequest request = HttpRequest
@@ -211,6 +229,23 @@ public class BridgeTest {
         assertThat(rpcResponse).isEqualTo(responseFor(rpcRequest
                 .toBuilder()
                 .setStringField("hello")
+                .build()));
+    }
+
+    @Test
+    public void get_withSuffix_encoded() {
+        GetRequest rpcRequest = newGetRequest();
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get/h%3Del%2Fl%26o/suffix")
+                .body(serialize(rpcRequest))
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        GetResponse rpcResponse = parse(response.getBody(), GetResponse.newBuilder());
+
+        assertThat(rpcResponse).isEqualTo(responseFor(rpcRequest
+                .toBuilder()
+                .setStringField("h=el/l&o")
                 .build()));
     }
 
@@ -480,7 +515,7 @@ public class BridgeTest {
             assertThat(ex.getTrailers()).isNull();
         }
     }
-    
+
     @Test
     public void getWithInterceptor() {
         Bridge bridge = Bridge
@@ -521,7 +556,7 @@ public class BridgeTest {
                 .setStringField("hello")
                 .build()));
     }
-    
+
     @Test
     public void getStream() {
         GetRequest rpcRequest = newGetRequest();
@@ -531,7 +566,7 @@ public class BridgeTest {
                 .build();
 
         HttpResponse response = bridge.handle(request);
-        
+
         List<GetResponse> responses = parseStream(response.getBody(), GetResponse.newBuilder());
         assertThat(responses.size()).isEqualTo(2);
         assertThat(responses.get(0).getStringField()).isEqualTo("hello");

--- a/lib/src/test/java/grpcbridge/route/UrlPathAndQueryTest.java
+++ b/lib/src/test/java/grpcbridge/route/UrlPathAndQueryTest.java
@@ -75,6 +75,12 @@ public class UrlPathAndQueryTest {
                 .containsEntry("p3", list("{pp3}"));
     }
 
+    @Test
+    public void decode() {
+        assertThat(UrlPathAndQuery.decode("%20%22%25%2D%2E%3C%3E%5C%5E%5F%60%7B%7C%7D%7E"))
+                .isEqualTo(" \"%-.<>\\^_`{|}~");
+    }
+
     private static <T> List<T> list(T t) {
         return Collections.singletonList(t);
     }


### PR DESCRIPTION
Currently url encoded path variables are not decoded before they are converted to protobuf fields.

Adds support for url encoded path variables by decoding individual path segments after they are matched to a field.