### PR TITLE
Only attach Span to Context for current call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.14'
+    version = '1.2.15'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/main/java/grpcbridge/monitoring/Tracer.java
+++ b/lib/src/main/java/grpcbridge/monitoring/Tracer.java
@@ -69,17 +69,16 @@ public final class Tracer {
             }
         }
 
-        Scope scope = Tracing.getTracer()
+        Span span = Tracing.getTracer()
                 .spanBuilderWithRemoteParent("grpcbridge/http", context)
-                .startScopedSpan();
-        Span span = Tracing.getTracer().getCurrentSpan();
+                .startSpan();
         span.putAttribute(
                 "service",
                 AttributeValue.stringAttributeValue(route.getService()));
         span.putAttribute(
                 "method",
                 AttributeValue.stringAttributeValue(route.getMethod()));
-        return new TracingSpan(scope, span);
+        return new TracingSpan(span);
     }
 
     private static Key<String> key(String header) {

--- a/lib/src/main/java/grpcbridge/monitoring/TracingSpan.java
+++ b/lib/src/main/java/grpcbridge/monitoring/TracingSpan.java
@@ -5,18 +5,26 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import grpcbridge.rpc.RpcMessage;
+import java.util.function.Supplier;
+
 import io.grpc.StatusRuntimeException;
 import io.opencensus.common.Scope;
+import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
+import io.opencensus.trace.Tracing;
 
 public class TracingSpan {
-    private final Scope scope;
     private final Span span;
 
-    protected TracingSpan(Scope scope, Span span) {
-        this.scope = scope;
+    protected TracingSpan(Span span) {
         this.span = span;
+    }
+
+    public <T> T callInContext(Supplier<T> action) {
+        try (Scope scope = Tracing.getTracer().withSpan(span)) {
+            return action.get();
+        }
     }
 
     public void attachTo(ListenableFuture<RpcMessage> future) {
@@ -47,7 +55,8 @@ public class TracingSpan {
     }
 
     public void close(Status status) {
-        span.setStatus(status);
-        scope.close();
+        span.end(EndSpanOptions.builder()
+                .setStatus(status)
+                .build());
     }
 }


### PR DESCRIPTION
Currently we are attaching the Span to the main Context and only detaching when the call closes. This can lead to nested unrelated Spans and a long Context ancestry chain.

Instead, we need to attach the Span to the current Context before call creation and detach immediately after, GRPC will automatically propagate the new Context/span for call lifecycle.

