### PR TITLE
Handle empty Span ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.15'
+    version = '1.2.16'
     group = 'grpcbridge'
 
     repositories {


### PR DESCRIPTION
Opencensus throws out the remote span if it is considered invalid (no Span ID or Trace ID). If we have a Trace ID but no Span ID, we should generate one so that we don't discard the Trace ID. Also, always unset Tracing Options so that clients can't force sampling instead of leaving it up to the installed Sampler to decide whether or not to sample.