### PR TITLE
Swagger bug fixes, support required fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.17'
+    version = '1.2.18'
     group = 'grpcbridge'
 
     repositories {

--- a/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
+++ b/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
@@ -4,7 +4,9 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.api.AnnotationsProto;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.FieldOptions;
 import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.GeneratedMessage.GeneratedExtension;
 
 import grpcbridge.http.BridgeHttpRule;
 import grpcbridge.route.SwaggerManifestGenerator;
@@ -12,11 +14,18 @@ import grpcbridge.route.Route;
 import grpcbridge.swagger.model.SwaggerRoute;
 import grpcbridge.swagger.model.SwaggerSchema;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Generates a Swagger 2.0 compatible API specification for the given routes.
  */
 public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGenerator {
+    private final SwaggerConfig config;
+
+    private BridgeSwaggerManifestGenerator(SwaggerConfig config) {
+        this.config = config;
+    }
+
     public String generate(List<Route> routes) {
         String serviceName = routes.stream()
             .map(Route::getService)
@@ -32,7 +41,7 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
                 options.getExtension(AnnotationsProto.http)
             );
 
-            ParametersBuilder parameters = ParametersBuilder.create(descriptor, rule);
+            ParametersBuilder parameters = ParametersBuilder.create(descriptor, rule, config);
             schema.putAllModels(parameters.getModelDefinitions());
             schema.addRoute(
                 rule.getPath(),
@@ -43,4 +52,49 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
 
         return schema.serialize();
     }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension;
+        private @Nullable FieldNameFormatter formatter;
+
+        /**
+         * Set extension to use to mark fields as required. Optional.
+         *
+         * @param extension extension
+         * @return this
+         */
+        public Builder setRequiredExtension(GeneratedExtension<FieldOptions, Boolean> extension) {
+            this.requiredExtension = extension;
+            return this;
+        }
+
+        /**
+         * Set field formatter.
+         *
+         * @param formatter field formatter
+         * @return this
+         */
+        public Builder setFormatter(FieldNameFormatter formatter) {
+            this.formatter = formatter;
+            return this;
+        }
+
+        /**
+         * Creates a {@link BridgeSwaggerManifestGenerator} instance.
+         *
+         * @return a {@link BridgeSwaggerManifestGenerator} instance
+         */
+        public BridgeSwaggerManifestGenerator build() {
+            SwaggerConfig config = new SwaggerConfig(
+                requiredExtension,
+                formatter != null ? formatter : FieldNameFormatter.snakeCase()
+            );
+            return new BridgeSwaggerManifestGenerator(config);
+        }
+    }
+
 }

--- a/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
+++ b/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package grpcbridge.swagger;
+
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.GeneratedMessage.GeneratedExtension;
+
+import javax.annotation.Nullable;
+
+/**
+ * Configures schema generation. Handles field name formatting and optional extensions.
+ */
+class SwaggerConfig {
+    private final @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension;
+    private final FieldNameFormatter formatter;
+
+    SwaggerConfig(
+        @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension,
+        FieldNameFormatter formatter
+    ) {
+        this.requiredExtension = requiredExtension;
+        this.formatter = formatter;
+    }
+
+    boolean isRequired(FieldDescriptor field) {
+        return requiredExtension != null && field.getOptions().getExtension(requiredExtension);
+    }
+
+    String formatFieldName(FieldDescriptor field) {
+        return formatter.nameFor(field);
+    }
+}

--- a/swagger/src/main/java/grpcbridge/swagger/model/EnumSwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/EnumSwaggerModel.java
@@ -27,7 +27,7 @@ public class EnumSwaggerModel extends SwaggerModel {
     }
 
     @Override
-    public void putProperty(String name, Property property) {
+    public void putProperty(String name, Property property, boolean isRequired) {
         throw new UnsupportedOperationException("Cannot put property on enum model definition");
     }
 }

--- a/swagger/src/main/java/grpcbridge/swagger/model/Parameter.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/Parameter.java
@@ -25,12 +25,14 @@ public abstract class Parameter {
     public static Parameter forSimpleField(
         String name,
         Location location,
-        FieldDescriptor simpleField
+        FieldDescriptor simpleField,
+        boolean required
     ) {
         return SimpleParameter.create(
             name,
             location,
-            SimpleProperty.forSimpleField(simpleField, SimpleFieldType.fromDescriptor(simpleField))
+            SimpleProperty.forSimpleField(simpleField, SimpleFieldType.fromDescriptor(simpleField)),
+            required
         );
     }
 
@@ -39,6 +41,10 @@ public abstract class Parameter {
             name,
             SimpleProperty.forSimpleField(simpleField, SimpleFieldType.fromDescriptor(simpleField))
         );
+    }
+
+    public String getName() {
+        return name;
     }
 
     protected Parameter(

--- a/swagger/src/main/java/grpcbridge/swagger/model/Property.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/Property.java
@@ -22,7 +22,8 @@ public abstract class Property {
             case INT:
                 return SimpleProperty.create(Type.INTEGER, "int32");
             case LONG:
-                return SimpleProperty.create(Type.INTEGER, "int64");
+                // GRPC converts long to string to prevent precision loss
+                return SimpleProperty.create(Type.STRING, "string");
             case BOOL:
                 return SimpleProperty.create(Type.BOOLEAN, "boolean");
             case DOUBLE:

--- a/swagger/src/main/java/grpcbridge/swagger/model/SimpleParameter.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SimpleParameter.java
@@ -26,14 +26,15 @@ class SimpleParameter extends Parameter {
     static SimpleParameter create(
         String name,
         Location location,
-        SimpleProperty property
+        SimpleProperty property,
+        boolean required
     ) {
         return new SimpleParameter(
             property.type,
             property.defaultValue,
             name,
             location,
-            location == Location.PATH,
+            required || location == Location.PATH,
             property.format,
             property.enumValues
         );

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
@@ -31,7 +31,15 @@ public class SwaggerModel {
         return properties.get(name);
     }
 
-    public void putProperty(String name, Property property) {
+    public void putProperty(String name, Property property, boolean isRequired) {
         properties.put(name, property);
+        if (isRequired) {
+            required.add(name);
+        }
+    }
+
+    public void remove(String name) {
+        properties.remove(name);
+        required.remove(name);
     }
 }

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerRoute.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerRoute.java
@@ -1,5 +1,6 @@
 package grpcbridge.swagger.model;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
 import com.google.common.collect.ImmutableMap;
@@ -32,8 +33,8 @@ public class SwaggerRoute {
 
     public static SwaggerRoute create(MethodDescriptor method, List<Parameter> parameters) {
         return new SwaggerRoute(
-            method.getName(),
-            ImmutableMap.of("200", Response.create(method)),
+            format("%s.%s", method.getService().getName(), method.getName()),
+            ImmutableMap.of("200", Response.create("Successful response", method)),
             parameters,
             emptyList()
         );
@@ -52,9 +53,9 @@ public class SwaggerRoute {
             this.schema = schema;
         }
 
-        private static Response create(MethodDescriptor methodDescriptor) {
+        private static Response create(String description, MethodDescriptor methodDescriptor) {
             return new Response(
-                null,
+                description,
                 ReferenceProperty.create(methodDescriptor.getOutputType())
             );
         }

--- a/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
+++ b/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
@@ -1,9 +1,14 @@
 package grpcbridge.swagger;
 
+import static grpcbridge.test.proto.Test.testRequired;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import grpcbridge.Bridge;
 import grpcbridge.test.proto.TestServiceGrpc.TestServiceImplBase;
@@ -19,11 +24,13 @@ public class BridgeSwaggerManifestGeneratorTest {
 
     @Test
     public void generateManifest() {
-        String manifest = bridge.generateManifest(new BridgeSwaggerManifestGenerator());
-        String expected = load("test-proto-swagger.json")
-            .replaceAll("\n", "")
-            .replaceAll(" ", "");
-        assertThat(manifest).isEqualTo(expected);
+        String manifest = bridge.generateManifest(
+            BridgeSwaggerManifestGenerator.newBuilder()
+                .setRequiredExtension(testRequired)
+                .build()
+        );
+        String expected = load("test-proto-swagger.json");
+        assertThat(formatJson(manifest)).isEqualTo(expected);
     }
 
     private String load(String fileName) {
@@ -32,5 +39,12 @@ public class BridgeSwaggerManifestGeneratorTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String formatJson(String jsonString) {
+        JsonParser parser = new JsonParser();
+        JsonObject json = parser.parse(jsonString).getAsJsonObject();
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(json);
     }
 }

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -3,15 +3,24 @@ package grpcbridge.test.proto;
 
 import "included-test-file.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/descriptor.proto";
 
 enum Enum { INVALID = 0; VALID = 1; }
+
+extend google.protobuf.FieldOptions {
+  bool test_required = 50000;
+}
 
 message Nested {
   string nested_field = 1;
 }
 
+message RepeatedNested {
+  string repeated_nested_field = 1;
+}
+
 message GetRequest {
-  string string_field = 1;
+  string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
   int64 long_field = 3;
   float float_field = 4;
@@ -51,7 +60,7 @@ message GetResponse {
 }
 
 message PostRequest {
-  string string_field = 1;
+  string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
 }
 
@@ -60,12 +69,24 @@ message PostResponse {
   int32 int_field = 2;
 }
 
+message PostBodyRequest {
+  string string_field = 1 [(test_required) = true];
+  int32 int_field = 2;
+}
+
+message PostBodyResponse {
+  string string_field = 1;
+  int32 int_field = 2;
+}
+
 message PutRequest {
   string string_field = 1;
+  repeated RepeatedNested repeated_message = 2;
 }
 
 message PutResponse {
   string string_field = 1;
+  repeated RepeatedNested repeated_message = 2;
 }
 
 message DeleteRequest {
@@ -116,9 +137,16 @@ service TestService {
     };
   }
 
+  rpc PostBody (PostBodyRequest) returns (PostBodyResponse) {
+    option (google.api.http) = {
+        post: "/post-body"
+        body: "*"
+    };
+  }
+
   rpc PostNoBody (PostRequest) returns (PostResponse) {
     option (google.api.http) = {
-        post: "/post-no-body/{string_field}"
+        post: "/post-no-body/{int_field}"
     };
   }
 

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -12,9 +12,10 @@
   "paths": {
     "/delete/{string_field}": {
       "delete": {
-        "operationId": "Delete",
+        "operationId": "TestService.Delete",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.DeleteResponse"
             }
@@ -31,39 +32,12 @@
         "tags": []
       }
     },
-    "/post-no-body/{string_field}": {
-      "post": {
-        "operationId": "PostNoBody",
-        "responses": {
-          "200": {
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "string_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "format": "int32",
-            "name": "int_field",
-            "in": "query",
-            "required": false,
-            "type": "integer"
-          }
-        ],
-        "tags": []
-      }
-    },
     "/get-nested/{nested.nested_field}": {
       "get": {
-        "operationId": "GetNestedParams",
+        "operationId": "TestService.GetNestedParams",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
             }
@@ -73,7 +47,7 @@
           {
             "name": "string_field",
             "in": "query",
-            "required": false,
+            "required": true,
             "type": "string"
           },
           {
@@ -84,11 +58,11 @@
             "type": "integer"
           },
           {
-            "format": "int64",
+            "format": "string",
             "name": "long_field",
             "in": "query",
             "required": false,
-            "type": "integer"
+            "type": "string"
           },
           {
             "format": "float",
@@ -179,9 +153,10 @@
     },
     "/patch/{string_field}": {
       "patch": {
-        "operationId": "Patch",
+        "operationId": "TestService.Patch",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.PatchResponse"
             }
@@ -200,9 +175,10 @@
     },
     "/get-static": {
       "get": {
-        "operationId": "GetStatic",
+        "operationId": "TestService.GetStatic",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
             }
@@ -212,7 +188,7 @@
           {
             "name": "string_field",
             "in": "query",
-            "required": false,
+            "required": true,
             "type": "string"
           },
           {
@@ -223,11 +199,11 @@
             "type": "integer"
           },
           {
-            "format": "int64",
+            "format": "string",
             "name": "long_field",
             "in": "query",
             "required": false,
-            "type": "integer"
+            "type": "string"
           },
           {
             "format": "float",
@@ -318,9 +294,10 @@
     },
     "/put/{string_field}": {
       "put": {
-        "operationId": "Put",
+        "operationId": "TestService.Put",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.PutResponse"
             }
@@ -345,11 +322,36 @@
         "tags": []
       }
     },
-    "/get/{string_field}": {
-      "get": {
-        "operationId": "Get",
+    "/post-body": {
+      "post": {
+        "operationId": "TestService.PostBody",
         "responses": {
           "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
+    },
+    "/get/{string_field}": {
+      "get": {
+        "operationId": "TestService.Get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
             }
@@ -370,11 +372,11 @@
             "type": "integer"
           },
           {
-            "format": "int64",
+            "format": "string",
             "name": "long_field",
             "in": "query",
             "required": false,
-            "type": "integer"
+            "type": "string"
           },
           {
             "format": "float",
@@ -463,11 +465,41 @@
         "tags": []
       }
     },
-    "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}": {
-      "get": {
-        "operationId": "GetMultipleParams",
+    "/post-no-body/{int_field}": {
+      "post": {
+        "operationId": "TestService.PostNoBody",
         "responses": {
           "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "format": "int32",
+            "name": "int_field",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "tags": []
+      }
+    },
+    "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}": {
+      "get": {
+        "operationId": "TestService.GetMultipleParams",
+        "responses": {
+          "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
             }
@@ -488,11 +520,11 @@
             "type": "integer"
           },
           {
-            "format": "int64",
+            "format": "string",
             "name": "long_field",
             "in": "path",
             "required": true,
-            "type": "integer"
+            "type": "string"
           },
           {
             "format": "float",
@@ -583,9 +615,10 @@
     },
     "/post-custom/{string_field}": {
       "post": {
-        "operationId": "PostCustomBody",
+        "operationId": "TestService.PostCustomBody",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
             }
@@ -604,9 +637,10 @@
     },
     "/post/{string_field}": {
       "post": {
-        "operationId": "Post",
+        "operationId": "TestService.Post",
         "responses": {
           "200": {
+            "description": "Successful response",
             "schema": {
               "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
             }
@@ -633,15 +667,6 @@
     }
   },
   "definitions": {
-    "grpcbridge.test.proto.PatchResponse": {
-      "type": "object",
-      "properties": {
-        "string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
     "grpcbridge.test.proto.Enum": {
       "enum": [
         "INVALID",
@@ -651,10 +676,10 @@
       "type": "string",
       "required": []
     },
-    "grpcbridge.test.proto.GetResponse.external_field": {
+    "grpcbridge.test.proto.RepeatedNested": {
       "type": "object",
       "properties": {
-        "external_string_field": {
+        "repeated_nested_field": {
           "type": "string"
         }
       },
@@ -664,24 +689,6 @@
       "type": "object",
       "properties": {
         "string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
-    "grpcbridge.test.proto.GetResponse.message_one_of": {
-      "type": "object",
-      "properties": {
-        "nested_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
-    "grpcbridge.test.proto.GetResponse.nested": {
-      "type": "object",
-      "properties": {
-        "nested_field": {
           "type": "string"
         }
       },
@@ -698,8 +705,8 @@
           "$ref": "#/definitions/grpcbridge.test.proto.Enum"
         },
         "long_field": {
-          "format": "int64",
-          "type": "integer"
+          "format": "string",
+          "type": "string"
         },
         "nested": {
           "$ref": "#/definitions/grpcbridge.test.proto.Nested"
@@ -747,7 +754,26 @@
       },
       "required": []
     },
+    "grpcbridge.test.proto.Nested": {
+      "type": "object",
+      "properties": {
+        "nested_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
     "grpcbridge.test.proto.PostRequest": {
+      "type": "object",
+      "properties": {
+        "int_field": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PostBodyRequest": {
       "type": "object",
       "properties": {
         "int_field": {
@@ -758,20 +784,19 @@
           "type": "string"
         }
       },
-      "required": []
-    },
-    "grpcbridge.test.proto.PutRequest": {
-      "type": "object",
-      "properties": {
-        "string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
+      "required": [
+        "string_field"
+      ]
     },
     "grpcbridge.test.proto.PutResponse": {
       "type": "object",
       "properties": {
+        "repeated_message": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.RepeatedNested"
+          },
+          "type": "array"
+        },
         "string_field": {
           "type": "string"
         }
@@ -787,6 +812,49 @@
         },
         "string_field": {
           "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PatchResponse": {
+      "type": "object",
+      "properties": {
+        "string_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PostBodyResponse": {
+      "type": "object",
+      "properties": {
+        "int_field": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "string_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.included.proto.ExternalMessage": {
+      "type": "object",
+      "properties": {
+        "external_string_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PutRequest": {
+      "type": "object",
+      "properties": {
+        "repeated_message": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.RepeatedNested"
+          },
+          "type": "array"
         }
       },
       "required": []


### PR DESCRIPTION
- Adds support for required fields: user needs to supply an extension to use as "required"
- Remove fields from request body that are in the path or query
- Mark int64 as strings
- Use unique names for routes (service + method name)