### PR TITLE
Support for default value field extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.19'
+    version = '1.2.20'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/main/java/grpcbridge/route/ExtensionVisitor.java
+++ b/lib/src/main/java/grpcbridge/route/ExtensionVisitor.java
@@ -1,0 +1,55 @@
+package grpcbridge.route;
+
+import static grpcbridge.GrpcbridgeOptions.serializeDefaultValue;
+
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Extension;
+
+import grpcbridge.util.ProtoDescriptorTraverser;
+import grpcbridge.util.ProtoVisitor;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Proto visitor which retrieves all fields (including nested) in a message that have an extension
+ * matching the given extension.
+ */
+final class ExtensionVisitor<T> extends ProtoVisitor {
+    private final Extension<FieldOptions, T> extension;
+    private final T value;
+    private final Set<FieldDescriptor> matchingFields = new HashSet<>();
+
+    private ExtensionVisitor(Extension<FieldOptions, T> extension, T value) {
+        this.extension = extension;
+        this.value = value;
+    }
+
+    /**
+     * Returns all fields that have {@code serializeDefaultValue} set.
+     *
+     * @param message message to traverse
+     * @return matched fields
+     */
+    static Set<FieldDescriptor> serializeDefaultValueFields(Descriptor message) {
+        return fieldsWithExtension(message, serializeDefaultValue, true);
+    }
+
+    private static <T> Set<FieldDescriptor> fieldsWithExtension(
+        Descriptor message,
+        Extension<FieldOptions, T> extension,
+        T value
+    ) {
+        ExtensionVisitor<T> visitor = new ExtensionVisitor<>(extension, value);
+        new ProtoDescriptorTraverser(visitor).traverse(message);
+        return visitor.matchingFields;
+    }
+
+    @Override
+    public void onBeforeField(FieldDescriptor field) {
+        if (field.getOptions().getExtension(extension).equals(value)) {
+            matchingFields.add(field);
+        }
+    }
+}

--- a/lib/src/main/java/grpcbridge/route/Route.java
+++ b/lib/src/main/java/grpcbridge/route/Route.java
@@ -1,8 +1,11 @@
 package grpcbridge.route;
 
+import static grpcbridge.route.ExtensionVisitor.serializeDefaultValueFields;
+
 import com.google.api.AnnotationsProto;
 import com.google.api.HttpRule;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
@@ -15,6 +18,7 @@ import io.grpc.ServerMethodDefinition;
 
 import java.io.ByteArrayInputStream;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A route used by the {@link grpcbridge.Bridge} to match HTTP requests to the
@@ -75,6 +79,11 @@ public final class Route {
                 .getExtension(GrpcbridgeOptions.includeDefaultValues);
         if (includeDefaultValues) {
             printer = printer.includingDefaultValueFields();
+        } else {
+            Set<FieldDescriptor> fields = serializeDefaultValueFields(descriptor.getOutputType());
+            if (!fields.isEmpty()) {
+                printer = printer.includingDefaultValueFields(fields);
+            }
         }
         boolean serializeEnumAsNumber = descriptor
                 .getOptions()

--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -87,9 +87,9 @@ public class ProtoDescriptorTraverser {
     private void onMessageField(FieldDescriptor field) {
         visitor.onMessageStart(field);
         field.getMessageType().getFields().forEach(fieldDescriptor -> {
-            visitor.onBeforeField(field);
+            visitor.onBeforeField(fieldDescriptor);
             onField(fieldDescriptor);
-            visitor.onAfterField(field);
+            visitor.onAfterField(fieldDescriptor);
         });
         visitor.onMessageEnd(field);
     }

--- a/lib/src/main/proto/grpcbridge/grpcbridge-options.proto
+++ b/lib/src/main/proto/grpcbridge/grpcbridge-options.proto
@@ -12,3 +12,7 @@ extend google.protobuf.ServiceOptions {
 extend google.protobuf.MethodOptions {
   bool serialize_enum_as_number = 70000;
 }
+
+extend google.protobuf.FieldOptions {
+  bool serialize_default_value = 51000;
+}

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -26,6 +26,7 @@ import grpcbridge.common.TestService;
 import grpcbridge.http.HttpRequest;
 import grpcbridge.http.HttpResponse;
 import grpcbridge.parser.ProtoJsonConverter;
+import grpcbridge.test.proto.Test.DefaultMessage;
 import grpcbridge.test.proto.Test.DeleteRequest;
 import grpcbridge.test.proto.Test.DeleteResponse;
 import grpcbridge.test.proto.Test.GetRequest;
@@ -276,6 +277,7 @@ public class BridgeTest implements ProtoParseTest {
                 .setBytesField(ByteString.copyFrom("bytes".getBytes()))
                 .setEnumField(INVALID)
                 .setNested(Nested.newBuilder().setNestedField("nested"))
+                .setDefault(DefaultMessage.getDefaultInstance())
                 .build());
     }
 
@@ -548,6 +550,26 @@ public class BridgeTest implements ProtoParseTest {
         assertThat(rpcResponse).isEqualTo(responseFor(GetRequest.newBuilder()
                 .setStringField("hello")
                 .build()));
+    }
+
+    @Test
+    public void get_defaultValues() {
+        HttpRequest request = HttpRequest
+            .builder(GET, "/get")
+            .build();
+
+        HttpResponse response = bridge.handle(request);
+        String rpcResponse = response.getBody().replace(" ", "").replace("\n", "");
+
+        assertThat(rpcResponse).isEqualTo("{"
+            + "\"nested\":{},"
+            + "\"default\":{"
+                + "\"defaultString\":\"\","
+                + "\"defaultInt\":0,"
+                + "\"defaultBool\":false,"
+                + "\"defaultEnum\":\"INVALID\","
+                + "\"defaultRepeated\":[]"
+            + "}}");
     }
 
     private <T extends Message> List<T> parseStream(@Nullable String body, T.Builder builder) {

--- a/lib/src/test/java/grpcbridge/common/TestFactory.java
+++ b/lib/src/test/java/grpcbridge/common/TestFactory.java
@@ -34,6 +34,7 @@ public final class TestFactory {
                 .setBytesField(request.getBytesField())
                 .setNested(request.getNested())
                 .addAllRepeatedField(request.getRepeatedFieldList())
+                .setDefault(request.getDefault())
                 .build();
     }
 

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -46,6 +46,7 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
                 .setBytesField(request.getBytesField())
                 .setNested(request.getNested())
                 .addAllRepeatedField(request.getRepeatedFieldList())
+                .setDefault(request.getDefault())
                 .build());
         responseObserver.onCompleted();
     }

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -2,11 +2,21 @@ syntax = "proto3";
 package grpcbridge.test.proto;
 
 import "google/api/annotations.proto";
+import "grpcbridge/grpcbridge-options.proto";
 
 enum Enum { INVALID = 0; VALID = 1; }
 
 message Nested {
   string nested_field = 1;
+}
+
+message DefaultMessage {
+  string default_string = 1 [(grpcbridge.serialize_default_value) = true];
+  int32 default_int = 2 [(grpcbridge.serialize_default_value) = true];
+  bool default_bool = 3 [(grpcbridge.serialize_default_value) = true];
+  Enum default_enum= 4 [(grpcbridge.serialize_default_value) = true];
+  Nested default_nested = 5 [(grpcbridge.serialize_default_value) = true];
+  repeated string default_repeated = 6 [(grpcbridge.serialize_default_value) = true];
 }
 
 message GetRequest {
@@ -20,6 +30,7 @@ message GetRequest {
   Enum enum_field = 8;
   Nested nested = 9;
   repeated string repeated_field = 10;
+  DefaultMessage default = 11;
 }
 
 message GetResponse {
@@ -33,6 +44,8 @@ message GetResponse {
   Enum enum_field = 8;
   Nested nested = 9;
   repeated string repeated_field = 10;
+  DefaultMessage default = 11;
+  DefaultMessage unset_default = 12;
 }
 
 message PostRequest {

--- a/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
+++ b/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
@@ -1,5 +1,6 @@
 package grpcbridge.swagger;
 
+import static grpcbridge.GrpcbridgeOptions.serializeDefaultValue;
 import static java.util.stream.Collectors.joining;
 
 import com.google.api.AnnotationsProto;
@@ -13,7 +14,9 @@ import grpcbridge.route.SwaggerManifestGenerator;
 import grpcbridge.route.Route;
 import grpcbridge.swagger.model.SwaggerRoute;
 import grpcbridge.swagger.model.SwaggerSchema;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -58,7 +61,7 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
     }
 
     public static class Builder {
-        private @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension;
+        private Set<GeneratedExtension<FieldOptions, Boolean>> requiredExtensions = new HashSet<>();
         private @Nullable FieldNameFormatter formatter;
 
         /**
@@ -67,8 +70,8 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
          * @param extension extension
          * @return this
          */
-        public Builder setRequiredExtension(GeneratedExtension<FieldOptions, Boolean> extension) {
-            this.requiredExtension = extension;
+        public Builder addRequiredExtension(GeneratedExtension<FieldOptions, Boolean> extension) {
+            this.requiredExtensions.add(extension);
             return this;
         }
 
@@ -89,8 +92,11 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
          * @return a {@link BridgeSwaggerManifestGenerator} instance
          */
         public BridgeSwaggerManifestGenerator build() {
+            // Fields that print default values will always be present
+            requiredExtensions.add(serializeDefaultValue);
+
             SwaggerConfig config = new SwaggerConfig(
-                requiredExtension,
+                requiredExtensions,
                 formatter != null ? formatter : FieldNameFormatter.snakeCase()
             );
             return new BridgeSwaggerManifestGenerator(config);

--- a/swagger/src/main/java/grpcbridge/swagger/ModelBuilder.java
+++ b/swagger/src/main/java/grpcbridge/swagger/ModelBuilder.java
@@ -8,9 +8,9 @@ import grpcbridge.swagger.model.EnumSwaggerModel;
 import grpcbridge.swagger.model.SwaggerModel;
 import grpcbridge.util.ProtoDescriptorTraverser;
 import grpcbridge.util.ProtoVisitor;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
+import java.util.TreeMap;
 
 /**
  * Proto Visitor which builds a {@link SwaggerModel} for the given input type and all included
@@ -18,7 +18,7 @@ import java.util.Stack;
  */
 class ModelBuilder extends ProtoVisitor {
     private final Stack<SwaggerModel> models = new Stack<>();
-    private final Map<String, SwaggerModel> completeDefinitions = new HashMap<>();
+    private final Map<String, SwaggerModel> completeDefinitions = new TreeMap<>();
     private final Descriptor rootDescriptor;
     private final SwaggerConfig config;
 

--- a/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
+++ b/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
@@ -16,13 +16,13 @@ import grpcbridge.util.ProtoDescriptorTraverser;
 import grpcbridge.util.ProtoVisitor;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * Proto Visitor which extracts {@link Parameter} and {@link SwaggerModel} definitions for a given
@@ -31,7 +31,7 @@ import java.util.Stack;
 class ParametersBuilder extends ProtoVisitor {
     private final Stack<String> jsonPath = new Stack<>();
     private final List<Parameter> parameters = new LinkedList<>();
-    private final Map<String, SwaggerModel> modelDefinitions = new HashMap<>();
+    private final Map<String, SwaggerModel> modelDefinitions = new TreeMap<>();
     private final MethodDescriptor method;
     private final SwaggerConfig config;
     private final FieldLocator locator;
@@ -149,7 +149,7 @@ class ParametersBuilder extends ProtoVisitor {
         private final boolean bodyIsWildCard;
 
         private FieldLocator(BridgeHttpRule rule) {
-            pathParameters = new HashSet<>(new VariableExtractor(rule.getPath()).getPathVars());
+            pathParameters = new TreeSet<>(new VariableExtractor(rule.getPath()).getPathVars());
             bodyIsWildCard = rule.getBody().equals(WILD_CARD);
             if (rule.getBody().isEmpty() || bodyIsWildCard) {
                 bodyParameter = null;

--- a/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
+++ b/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
@@ -4,25 +4,28 @@ import com.google.protobuf.DescriptorProtos.FieldOptions;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.GeneratedMessage.GeneratedExtension;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
  * Configures schema generation. Handles field name formatting and optional extensions.
  */
 class SwaggerConfig {
-    private final @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension;
+    private final Set<GeneratedExtension<FieldOptions, Boolean>> requiredExtensions;
     private final FieldNameFormatter formatter;
 
     SwaggerConfig(
-        @Nullable GeneratedExtension<FieldOptions, Boolean> requiredExtension,
+        Set<GeneratedExtension<FieldOptions, Boolean>> requiredExtensions,
         FieldNameFormatter formatter
     ) {
-        this.requiredExtension = requiredExtension;
+        this.requiredExtensions = requiredExtensions;
         this.formatter = formatter;
     }
 
     boolean isRequired(FieldDescriptor field) {
-        return requiredExtension != null && field.getOptions().getExtension(requiredExtension);
+        return requiredExtensions
+            .stream()
+            .anyMatch(extension -> field.getOptions().getExtension(extension));
     }
 
     String formatFieldName(FieldDescriptor field) {

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
@@ -1,10 +1,10 @@
 package grpcbridge.swagger.model;
 
 import grpcbridge.swagger.model.Property.Type;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Defines a Swagger model.
@@ -20,11 +20,11 @@ public class SwaggerModel {
     }
 
     public static SwaggerModel forMessage() {
-        return new SwaggerModel(Type.OBJECT, new HashMap<>());
+        return new SwaggerModel(Type.OBJECT, new TreeMap<>());
     }
 
     public static SwaggerModel empty() {
-        return new SwaggerModel(Type.ARRAY, new HashMap<>());
+        return new SwaggerModel(Type.ARRAY, new TreeMap<>());
     }
 
     public Property getProperty(String name) {

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerSchema.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerSchema.java
@@ -11,9 +11,9 @@ import grpcbridge.swagger.gson.LowercaseEnumTypeAdapterFactory;
 import grpcbridge.swagger.model.Parameter.Location;
 import grpcbridge.swagger.model.Property.Type;
 import grpcbridge.swagger.model.RepeatedQueryParameter.CollectionFormat;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Full Swagger schema definition. Supports serialization.
@@ -32,8 +32,8 @@ public class SwaggerSchema {
     private final List<String> schemes = singletonList("https");
     private final List<String> consumes = singletonList("application/json");
     private final List<String> produces = singletonList("application/json");
-    private final Map<String, Map<HttpMethod, SwaggerRoute>> paths = new HashMap<>();
-    private final Map<String, SwaggerModel> definitions = new HashMap<>();
+    private final Map<String, Map<HttpMethod, SwaggerRoute>> paths = new TreeMap<>();
+    private final Map<String, SwaggerModel> definitions = new TreeMap<>();
     private final InfoJson info;
 
     private SwaggerSchema(InfoJson info) {
@@ -45,7 +45,7 @@ public class SwaggerSchema {
     }
 
     public void addRoute(String path, HttpMethod method, SwaggerRoute route) {
-        paths.putIfAbsent(path, new HashMap<>());
+        paths.putIfAbsent(path, new TreeMap<>());
         if (paths.get(path).containsKey(method)) {
             throw new IllegalStateException(
                 String.format("Duplicate definition for %s %s found", method, route.getName())

--- a/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
+++ b/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
@@ -26,7 +26,7 @@ public class BridgeSwaggerManifestGeneratorTest {
     public void generateManifest() {
         String manifest = bridge.generateManifest(
             BridgeSwaggerManifestGenerator.newBuilder()
-                .setRequiredExtension(testRequired)
+                .addRequiredExtension(testRequired)
                 .build()
         );
         String expected = load("test-proto-swagger.json");

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -4,6 +4,7 @@ package grpcbridge.test.proto;
 import "included-test-file.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/descriptor.proto";
+import "grpcbridge/grpcbridge-options.proto";
 
 enum Enum { INVALID = 0; VALID = 1; }
 
@@ -41,7 +42,7 @@ message GetRequest {
 
 message GetResponse {
   string string_field = 1;
-  int32 int_field = 2;
+  int32 int_field = 2 [(grpcbridge.serialize_default_value) = true];
   int64 long_field = 3;
   float float_field = 4;
   double double_field = 5;

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -753,6 +753,7 @@
         }
       },
       "required": [
+        "int_field",
         "nested"
       ]
     },

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -32,6 +32,125 @@
         "tags": []
       }
     },
+    "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}": {
+      "get": {
+        "operationId": "TestService.GetMultipleParams",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "format": "int32",
+            "name": "int_field",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "format": "string",
+            "name": "long_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "format": "float",
+            "name": "float_field",
+            "in": "path",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "format": "double",
+            "name": "double_field",
+            "in": "path",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "format": "boolean",
+            "name": "bool_field",
+            "in": "path",
+            "required": true,
+            "type": "boolean"
+          },
+          {
+            "format": "byte",
+            "name": "bytes_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "enum": [
+              "INVALID",
+              "VALID"
+            ],
+            "name": "enum_field",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "default": "INVALID"
+          },
+          {
+            "name": "nested.nested_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
+            "name": "repeated_field",
+            "in": "query",
+            "required": false,
+            "type": "array"
+          },
+          {
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
+            "name": "repeated_enum",
+            "in": "query",
+            "required": false,
+            "type": "array"
+          },
+          {
+            "name": "external_field.external_string_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "string_one_of",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "message_one_of.nested_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": []
+      }
+    },
     "/get-nested/{nested.nested_field}": {
       "get": {
         "operationId": "TestService.GetNestedParams",
@@ -145,28 +264,6 @@
             "name": "message_one_of.nested_field",
             "in": "query",
             "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": []
-      }
-    },
-    "/patch/{string_field}": {
-      "patch": {
-        "operationId": "TestService.Patch",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PatchResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "string_field",
-            "in": "path",
-            "required": true,
             "type": "string"
           }
         ],
@@ -292,60 +389,6 @@
         "tags": []
       }
     },
-    "/put/{string_field}": {
-      "put": {
-        "operationId": "TestService.Put",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PutResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "string_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PutRequest"
-            },
-            "name": "body",
-            "in": "body",
-            "required": true
-          }
-        ],
-        "tags": []
-      }
-    },
-    "/post-body": {
-      "post": {
-        "operationId": "TestService.PostBody",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyRequest"
-            },
-            "name": "body",
-            "in": "body",
-            "required": true
-          }
-        ],
-        "tags": []
-      }
-    },
     "/get/{string_field}": {
       "get": {
         "operationId": "TestService.Get",
@@ -465,6 +508,74 @@
         "tags": []
       }
     },
+    "/patch/{string_field}": {
+      "patch": {
+        "operationId": "TestService.Patch",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PatchResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": []
+      }
+    },
+    "/post-body": {
+      "post": {
+        "operationId": "TestService.PostBody",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostBodyRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
+    },
+    "/post-custom/{string_field}": {
+      "post": {
+        "operationId": "TestService.PostCustomBody",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": []
+      }
+    },
     "/post-no-body/{int_field}": {
       "post": {
         "operationId": "TestService.PostNoBody",
@@ -489,147 +600,6 @@
             "in": "path",
             "required": true,
             "type": "integer"
-          }
-        ],
-        "tags": []
-      }
-    },
-    "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}": {
-      "get": {
-        "operationId": "TestService.GetMultipleParams",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.GetResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "string_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "format": "int32",
-            "name": "int_field",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "format": "string",
-            "name": "long_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "format": "float",
-            "name": "float_field",
-            "in": "path",
-            "required": true,
-            "type": "number"
-          },
-          {
-            "format": "double",
-            "name": "double_field",
-            "in": "path",
-            "required": true,
-            "type": "number"
-          },
-          {
-            "format": "boolean",
-            "name": "bool_field",
-            "in": "path",
-            "required": true,
-            "type": "boolean"
-          },
-          {
-            "format": "byte",
-            "name": "bytes_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "enum": [
-              "INVALID",
-              "VALID"
-            ],
-            "name": "enum_field",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "default": "INVALID"
-          },
-          {
-            "name": "nested.nested_field",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "collectionFormat": "multi",
-            "items": {
-              "type": "string"
-            },
-            "name": "repeated_field",
-            "in": "query",
-            "required": false,
-            "type": "array"
-          },
-          {
-            "collectionFormat": "multi",
-            "items": {
-              "type": "string"
-            },
-            "name": "repeated_enum",
-            "in": "query",
-            "required": false,
-            "type": "array"
-          },
-          {
-            "name": "external_field.external_string_field",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "string_one_of",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "message_one_of.nested_field",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": []
-      }
-    },
-    "/post-custom/{string_field}": {
-      "post": {
-        "operationId": "TestService.PostCustomBody",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "schema": {
-              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "string_field",
-            "in": "path",
-            "required": true,
-            "type": "string"
           }
         ],
         "tags": []
@@ -664,22 +634,43 @@
         ],
         "tags": []
       }
+    },
+    "/put/{string_field}": {
+      "put": {
+        "operationId": "TestService.Put",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PutResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PutRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
     }
   },
   "definitions": {
-    "grpcbridge.test.proto.Enum": {
-      "enum": [
-        "INVALID",
-        "VALID"
-      ],
-      "default": "INVALID",
-      "type": "string",
-      "required": []
-    },
-    "grpcbridge.test.proto.RepeatedNested": {
+    "grpcbridge.test.included.proto.ExternalMessage": {
       "type": "object",
       "properties": {
-        "repeated_nested_field": {
+        "external_string_field": {
           "type": "string"
         }
       },
@@ -694,26 +685,18 @@
       },
       "required": []
     },
+    "grpcbridge.test.proto.Enum": {
+      "enum": [
+        "INVALID",
+        "VALID"
+      ],
+      "default": "INVALID",
+      "type": "string",
+      "required": []
+    },
     "grpcbridge.test.proto.GetResponse": {
       "type": "object",
       "properties": {
-        "float_field": {
-          "format": "float",
-          "type": "number"
-        },
-        "enum_field": {
-          "$ref": "#/definitions/grpcbridge.test.proto.Enum"
-        },
-        "long_field": {
-          "format": "string",
-          "type": "string"
-        },
-        "nested": {
-          "$ref": "#/definitions/grpcbridge.test.proto.Nested"
-        },
-        "string_field": {
-          "type": "string"
-        },
         "bool_field": {
           "format": "boolean",
           "type": "boolean"
@@ -722,21 +705,39 @@
           "format": "byte",
           "type": "string"
         },
+        "double_field": {
+          "format": "double",
+          "type": "number"
+        },
+        "enum_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.Enum"
+        },
+        "external_field": {
+          "$ref": "#/definitions/grpcbridge.test.included.proto.ExternalMessage"
+        },
+        "float_field": {
+          "format": "float",
+          "type": "number"
+        },
+        "int_field": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "long_field": {
+          "format": "string",
+          "type": "string"
+        },
+        "message_one_of": {
+          "$ref": "#/definitions/grpcbridge.test.proto.Nested"
+        },
+        "nested": {
+          "$ref": "#/definitions/grpcbridge.test.proto.Nested"
+        },
         "repeated_enum": {
           "items": {
             "type": "string"
           },
           "type": "array"
-        },
-        "string_one_of": {
-          "type": "string"
-        },
-        "external_field": {
-          "$ref": "#/definitions/grpcbridge.test.included.proto.ExternalMessage"
-        },
-        "int_field": {
-          "format": "int32",
-          "type": "integer"
         },
         "repeated_field": {
           "items": {
@@ -744,12 +745,11 @@
           },
           "type": "array"
         },
-        "double_field": {
-          "format": "double",
-          "type": "number"
+        "string_field": {
+          "type": "string"
         },
-        "message_one_of": {
-          "$ref": "#/definitions/grpcbridge.test.proto.Nested"
+        "string_one_of": {
+          "type": "string"
         }
       },
       "required": [
@@ -766,12 +766,11 @@
       },
       "required": []
     },
-    "grpcbridge.test.proto.PostRequest": {
+    "grpcbridge.test.proto.PatchResponse": {
       "type": "object",
       "properties": {
-        "int_field": {
-          "format": "int32",
-          "type": "integer"
+        "string_field": {
+          "type": "string"
         }
       },
       "required": []
@@ -791,17 +790,25 @@
         "string_field"
       ]
     },
-    "grpcbridge.test.proto.PutResponse": {
+    "grpcbridge.test.proto.PostBodyResponse": {
       "type": "object",
       "properties": {
-        "repeated_message": {
-          "items": {
-            "$ref": "#/definitions/grpcbridge.test.proto.RepeatedNested"
-          },
-          "type": "array"
+        "int_field": {
+          "format": "int32",
+          "type": "integer"
         },
         "string_field": {
           "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PostRequest": {
+      "type": "object",
+      "properties": {
+        "int_field": {
+          "format": "int32",
+          "type": "integer"
         }
       },
       "required": []
@@ -819,37 +826,6 @@
       },
       "required": []
     },
-    "grpcbridge.test.proto.PatchResponse": {
-      "type": "object",
-      "properties": {
-        "string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
-    "grpcbridge.test.proto.PostBodyResponse": {
-      "type": "object",
-      "properties": {
-        "int_field": {
-          "format": "int32",
-          "type": "integer"
-        },
-        "string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
-    "grpcbridge.test.included.proto.ExternalMessage": {
-      "type": "object",
-      "properties": {
-        "external_string_field": {
-          "type": "string"
-        }
-      },
-      "required": []
-    },
     "grpcbridge.test.proto.PutRequest": {
       "type": "object",
       "properties": {
@@ -858,6 +834,30 @@
             "$ref": "#/definitions/grpcbridge.test.proto.RepeatedNested"
           },
           "type": "array"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.PutResponse": {
+      "type": "object",
+      "properties": {
+        "repeated_message": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.RepeatedNested"
+          },
+          "type": "array"
+        },
+        "string_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.RepeatedNested": {
+      "type": "object",
+      "properties": {
+        "repeated_nested_field": {
+          "type": "string"
         }
       },
       "required": []


### PR DESCRIPTION
Adds a field extension that allows us to individually annotate fields whose default value should be serialized (eg empty array for repeated fields, false for booleans, etc..).

Also orders swagger route and model definitions to make diffs minimal.