### PR TITLE
Fix swagger generation for map fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.20'
+    version = '1.2.21'
     group = 'grpcbridge'
 
     repositories {

--- a/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
+++ b/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
@@ -97,7 +97,7 @@ class ParametersBuilder extends ProtoVisitor {
             );
         } else if (location == Location.QUERY && field.getJavaType() == JavaType.MESSAGE) {
             throw new IllegalArgumentException(
-                "Cannot put message in path: " + field.getFullName()
+                "Cannot put message in query: " + field.getFullName()
             );
         } else if (location == Location.BODY) {
             return;

--- a/swagger/src/main/java/grpcbridge/swagger/model/EnumSwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/EnumSwaggerModel.java
@@ -11,7 +11,7 @@ public class EnumSwaggerModel extends SwaggerModel {
     private final @SerializedName("default") String defaultValue;
 
     private EnumSwaggerModel(List<String> enumValues, String defaultValue) {
-        super(Type.STRING, null);
+        super(Type.STRING, null, null);
         this.enumValues = enumValues;
         this.defaultValue = defaultValue;
     }

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
@@ -1,5 +1,7 @@
 package grpcbridge.swagger.model;
 
+import static java.util.Collections.emptyMap;
+
 import grpcbridge.swagger.model.Property.Type;
 import java.util.LinkedList;
 import java.util.List;
@@ -13,18 +15,20 @@ public class SwaggerModel {
     private final Type type;
     private final Map<String, Property> properties;
     private final List<String> required = new LinkedList<>();
+    private final Property additionalProperties;
 
-    SwaggerModel(Type type, Map<String, Property> properties) {
+    SwaggerModel(Type type, Map<String, Property> properties, Property additionalProperties) {
         this.type = type;
         this.properties = properties;
+        this.additionalProperties = additionalProperties;
     }
 
     public static SwaggerModel forMessage() {
-        return new SwaggerModel(Type.OBJECT, new TreeMap<>());
+        return new SwaggerModel(Type.OBJECT, new TreeMap<>(), null);
     }
 
     public static SwaggerModel empty() {
-        return new SwaggerModel(Type.ARRAY, new TreeMap<>());
+        return new SwaggerModel(Type.ARRAY, new TreeMap<>(), null);
     }
 
     public Property getProperty(String name) {
@@ -45,5 +49,27 @@ public class SwaggerModel {
 
     public boolean hasProperties() {
         return properties.size() > 0;
+    }
+
+    public SwaggerModel asMapDefinition() {
+        if (type != Type.OBJECT) {
+            throw new IllegalArgumentException("Non-object model is not a map: " + type);
+        }
+
+        Property key = properties.get("key");
+        Property value = properties.get("value");
+        if (key == null || value == null) {
+            throw new IllegalArgumentException("Model is not a map entry, must have key/value");
+        }
+        if (key.type != Type.STRING) {
+            throw new IllegalArgumentException("Non-string map key not supported: " + key.type);
+        }
+        if (properties.size() != 2) {
+            throw new IllegalArgumentException(
+                "Model is not a map entry, must have exactly two fields"
+            );
+        }
+
+        return new SwaggerModel(Type.OBJECT, emptyMap(), value);
     }
 }

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -20,6 +20,11 @@ message RepeatedNested {
   string repeated_nested_field = 1;
 }
 
+message MapNested {
+  string string_field = 1;
+  map<string, Nested> map_field = 2;
+}
+
 message GetRequest {
   string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
@@ -53,6 +58,8 @@ message GetResponse {
   repeated string repeated_field = 10;
   repeated string repeated_enum = 15;
   grpcbridge.test.included.proto.ExternalMessage external_field = 11;
+  map<string, int32> int_map_field = 16;
+  map<string, MapNested> nested_map_field = 17;
 
   oneof one_of_field {
     string string_one_of = 13;
@@ -78,6 +85,8 @@ message PostBodyRequest {
 message PostBodyResponse {
   string string_field = 1;
   int32 int_field = 2;
+  map<string, int32> int_map_field = 16;
+  map<string, MapNested> nested_map_field = 17;
 }
 
 message PutRequest {

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -723,6 +723,9 @@
           "format": "int32",
           "type": "integer"
         },
+        "int_map_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.GetResponse.IntMapFieldEntry"
+        },
         "long_field": {
           "format": "string",
           "type": "string"
@@ -732,6 +735,9 @@
         },
         "nested": {
           "$ref": "#/definitions/grpcbridge.test.proto.Nested"
+        },
+        "nested_map_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.GetResponse.NestedMapFieldEntry"
         },
         "repeated_enum": {
           "items": {
@@ -756,6 +762,43 @@
         "int_field",
         "nested"
       ]
+    },
+    "grpcbridge.test.proto.GetResponse.IntMapFieldEntry": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "format": "int32",
+        "type": "integer"
+      }
+    },
+    "grpcbridge.test.proto.GetResponse.NestedMapFieldEntry": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.MapNested": {
+      "type": "object",
+      "properties": {
+        "map_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.MapNested.MapFieldEntry"
+        },
+        "string_field": {
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "grpcbridge.test.proto.MapNested.MapFieldEntry": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "$ref": "#/definitions/grpcbridge.test.proto.Nested"
+      }
     },
     "grpcbridge.test.proto.Nested": {
       "type": "object",
@@ -797,11 +840,34 @@
           "format": "int32",
           "type": "integer"
         },
+        "int_map_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.PostBodyResponse.IntMapFieldEntry"
+        },
+        "nested_map_field": {
+          "$ref": "#/definitions/grpcbridge.test.proto.PostBodyResponse.NestedMapFieldEntry"
+        },
         "string_field": {
           "type": "string"
         }
       },
       "required": []
+    },
+    "grpcbridge.test.proto.PostBodyResponse.IntMapFieldEntry": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "format": "int32",
+        "type": "integer"
+      }
+    },
+    "grpcbridge.test.proto.PostBodyResponse.NestedMapFieldEntry": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": {
+        "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
     },
     "grpcbridge.test.proto.PostRequest": {
       "type": "object",


### PR DESCRIPTION
The FieldDescriptor of a map field gets converted to a `repeated Entry`. When creating Swagger schema, check if a repeated field is actually a map and use an object with any "additionalProperties" instead.

Only supports maps with string keys since Swagger does not support non-string keys.