### PR TITLE
added code to set required list null if list is empty in swagger model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Maven:
 <dependency>
   <groupId>grpcbridge</groupId>
   <artifactId>grpcbridge</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile 'grpcbridge:grpcbridge:1.3.0'
+compile 'grpcbridge:grpcbridge:1.3.1'
 ```
 
 The library requires Java 8.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.3.0'
+    version = '1.3.1'
     group = 'grpcbridge'
 
     repositories {

--- a/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
+++ b/swagger/src/main/java/grpcbridge/swagger/model/SwaggerModel.java
@@ -14,7 +14,7 @@ import java.util.TreeMap;
 public class SwaggerModel {
     private final Type type;
     private final Map<String, Property> properties;
-    private final List<String> required = new LinkedList<>();
+    private List<String> required = null;
     private final Property additionalProperties;
 
     SwaggerModel(Type type, Map<String, Property> properties, Property additionalProperties) {
@@ -38,13 +38,21 @@ public class SwaggerModel {
     public void putProperty(String name, Property property, boolean isRequired) {
         properties.put(name, property);
         if (isRequired) {
+            if (required == null) {
+                required = new LinkedList<>();
+            }
             required.add(name);
         }
     }
 
     public void remove(String name) {
         properties.remove(name);
-        required.remove(name);
+        if (required != null) {
+            required.remove(name);
+            if (required.isEmpty()) {
+                required = null;
+            }
+        }
     }
 
     public boolean hasProperties() {

--- a/swagger/src/test/resources/petstore-openapi_v2-swagger.json
+++ b/swagger/src/test/resources/petstore-openapi_v2-swagger.json
@@ -207,13 +207,11 @@
         "order_id": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.CreatePetDeprecatedResponse": {
       "type": "object",
-      "properties": {},
-      "required": []
+      "properties": {}
     },
     "grpcbridge.test.proto.CreatePetResponse": {
       "type": "object",
@@ -221,18 +219,15 @@
         "pet_id": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.DeleteOrderResponse": {
       "type": "object",
-      "properties": {},
-      "required": []
+      "properties": {}
     },
     "grpcbridge.test.proto.DeletePetResponse": {
       "type": "object",
-      "properties": {},
-      "required": []
+      "properties": {}
     },
     "grpcbridge.test.proto.GetOrderResponse": {
       "type": "object",
@@ -240,8 +235,7 @@
         "pet_id": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.GetPetResponse": {
       "type": "object",
@@ -249,8 +243,7 @@
         "name": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     }
   },
   "info": {

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -673,8 +673,7 @@
         "external_string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.DeleteResponse": {
       "type": "object",
@@ -682,8 +681,7 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.Enum": {
       "enum": [
@@ -691,8 +689,7 @@
         "VALID"
       ],
       "default": "INVALID",
-      "type": "string",
-      "required": []
+      "type": "string"
     },
     "grpcbridge.test.proto.GetResponse": {
       "type": "object",
@@ -766,7 +763,6 @@
     "grpcbridge.test.proto.GetResponse.IntMapFieldEntry": {
       "type": "object",
       "properties": {},
-      "required": [],
       "additionalProperties": {
         "format": "int32",
         "type": "integer"
@@ -775,7 +771,6 @@
     "grpcbridge.test.proto.GetResponse.NestedMapFieldEntry": {
       "type": "object",
       "properties": {},
-      "required": [],
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
       }
@@ -789,13 +784,11 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.MapNested.MapFieldEntry": {
       "type": "object",
       "properties": {},
-      "required": [],
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.Nested"
       }
@@ -806,8 +799,7 @@
         "nested_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PatchResponse": {
       "type": "object",
@@ -815,8 +807,7 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PostBodyRequest": {
       "type": "object",
@@ -849,13 +840,11 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PostBodyResponse.IntMapFieldEntry": {
       "type": "object",
       "properties": {},
-      "required": [],
       "additionalProperties": {
         "format": "int32",
         "type": "integer"
@@ -864,7 +853,6 @@
     "grpcbridge.test.proto.PostBodyResponse.NestedMapFieldEntry": {
       "type": "object",
       "properties": {},
-      "required": [],
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
       }
@@ -876,8 +864,7 @@
           "format": "int32",
           "type": "integer"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PostResponse": {
       "type": "object",
@@ -889,8 +876,7 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PutRequest": {
       "type": "object",
@@ -901,8 +887,7 @@
           },
           "type": "array"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.PutResponse": {
       "type": "object",
@@ -916,8 +901,7 @@
         "string_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     },
     "grpcbridge.test.proto.RepeatedNested": {
       "type": "object",
@@ -925,8 +909,7 @@
         "repeated_nested_field": {
           "type": "string"
         }
-      },
-      "required": []
+      }
     }
   },
   "info": {


### PR DESCRIPTION
Currently, because of empty `required` list of `SwaggerModel`, it fails the validation, ie, using `./swagger/src/test/resources/test-proto-swagger.json` on  https://editor.swagger.io/  complains about structural errors. 

I don't know if related update to use array was for v3 support of swagger, even v3 does not allow empty arrays. My change was to set `required` property to null when it is empty, to ignore serialization. 