### PR TITLE
make interface FieldNameFormatter public 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.3.1'
+    version = '1.3.2'
     group = 'grpcbridge'
 
     repositories {

--- a/swagger/src/main/java/grpcbridge/swagger/FieldNameFormatter.java
+++ b/swagger/src/main/java/grpcbridge/swagger/FieldNameFormatter.java
@@ -2,7 +2,7 @@ package grpcbridge.swagger;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 
-interface FieldNameFormatter {
+public interface FieldNameFormatter {
     String nameFor(FieldDescriptor field);
 
     static FieldNameFormatter camelCase() {


### PR DESCRIPTION
as BridgeSwaggerManifestGenerator allows setting formatter, but type is not public.