### PR TITLE
GCP load balancer strips away span ID because they now support spans.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.3.4'
+    version = '1.3.5'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -553,6 +553,25 @@ public class BridgeTest implements ProtoParseTest {
     }
 
     @Test
+    public void get_withTracing_noSpanId() {
+        Metadata headers = new Metadata();
+        headers.put(
+                Key.of("X-Cloud-Trace-Context", ASCII_STRING_MARSHALLER),
+                "105445aa7843bc8bf206b12000100000");
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get/hello")
+                .headers(headers)
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        GetResponse rpcResponse = parse(response.getBody(), GetResponse.newBuilder());
+
+        assertThat(rpcResponse).isEqualTo(responseFor(GetRequest.newBuilder()
+                .setStringField("hello")
+                .build()));
+    }
+
+    @Test
     public void get_defaultValues() {
         HttpRequest request = HttpRequest
             .builder(GET, "/get")


### PR DESCRIPTION
But the formatter can't parse just the trace id alone, requires
trace-id/span-id format.