### PR TITLE
Added support for protobuf wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Maven:
 <dependency>
   <groupId>grpcbridge</groupId>
   <artifactId>grpcbridge</artifactId>
-  <version>1.3.4</version>
+  <version>1.3.6</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile 'grpcbridge:grpcbridge:1.3.4'
+compile 'grpcbridge:grpcbridge:1.3.6'
 ```
 
 The library requires Java 8.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.3.5'
+    version = '1.3.6'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/main/java/grpcbridge/route/Variable.java
+++ b/lib/src/main/java/grpcbridge/route/Variable.java
@@ -37,6 +37,9 @@ public final class Variable {
     private final String name;
     private final String value;
 
+    /**
+     * Maps supported wrapper types to a value parser.
+     */
     private final Map<Descriptor, Function<String, Object>> wrappers = new HashMap<Descriptor, Function<String, Object>>() {
         {
             put(DoubleValue.getDescriptor(), (s) -> DoubleValue.of(Double.parseDouble(s)));

--- a/lib/src/main/java/grpcbridge/route/Variable.java
+++ b/lib/src/main/java/grpcbridge/route/Variable.java
@@ -1,5 +1,8 @@
 package grpcbridge.route;
 
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -10,9 +13,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
 
 /**
  * Describes a variable that can be specified in {@link com.google.api.HttpRule}

--- a/lib/src/main/java/grpcbridge/route/Variable.java
+++ b/lib/src/main/java/grpcbridge/route/Variable.java
@@ -2,26 +2,14 @@ package grpcbridge.route;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.BytesValue;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.Descriptors.Descriptor;
-import com.google.protobuf.DoubleValue;
-import com.google.protobuf.FloatValue;
-import com.google.protobuf.Int32Value;
-import com.google.protobuf.Int64Value;
-import com.google.protobuf.StringValue;
-import com.google.protobuf.UInt32Value;
-import com.google.protobuf.UInt64Value;
+import grpcbridge.util.SimpleFieldMapper;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -36,23 +24,6 @@ import static java.util.Arrays.asList;
 public final class Variable {
     private final String name;
     private final String value;
-
-    /**
-     * Maps supported wrapper types to a value parser.
-     */
-    private final Map<Descriptor, Function<String, Object>> wrappers = new HashMap<Descriptor, Function<String, Object>>() {
-        {
-            put(DoubleValue.getDescriptor(), (s) -> DoubleValue.of(Double.parseDouble(s)));
-            put(FloatValue.getDescriptor(), (s) -> FloatValue.of(Float.parseFloat(s)));
-            put(Int64Value.getDescriptor(), (s) -> Int64Value.of(Long.parseLong(s)));
-            put(UInt64Value.getDescriptor(), (s) -> UInt64Value.of(Long.parseLong(s)));
-            put(Int32Value.getDescriptor(), (s) -> Int32Value.of(Integer.parseInt(s)));
-            put(UInt32Value.getDescriptor(), (s) -> UInt32Value.of(Integer.parseInt(s)));
-            put(BoolValue.getDescriptor(), (s) -> BoolValue.of(Boolean.parseBoolean(s)));
-            put(StringValue.getDescriptor(), StringValue::of);
-            put(BytesValue.getDescriptor(), (s) -> BytesValue.of(ByteString.copyFrom(s.getBytes())));
-        }
-    };
 
     /**
      * @param name variable name, e.g path.to.protobuf.field
@@ -107,8 +78,8 @@ public final class Variable {
             case ENUM:
                 return field.getEnumType().findValueByName(value);
             case MESSAGE:
-                if (wrappers.containsKey(field.getMessageType())) {
-                    return wrappers.get(field.getMessageType()).apply(value);
+                if (SimpleFieldMapper.isSupported(field)) {
+                    return SimpleFieldMapper.forDescriptor(field).parse(value);
                 }
             default:
                 throw new IllegalStateException("Unsupported field type found: " + field);

--- a/lib/src/main/java/grpcbridge/route/Variable.java
+++ b/lib/src/main/java/grpcbridge/route/Variable.java
@@ -6,6 +6,7 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
@@ -36,17 +37,17 @@ public final class Variable {
     private final String name;
     private final String value;
 
-    private final Map<String, Function<String, Object>> wrappers = new HashMap<String, Function<String, Object>>() {
+    private final Map<Descriptor, Function<String, Object>> wrappers = new HashMap<Descriptor, Function<String, Object>>() {
         {
-            put("google.protobuf.DoubleValue", (s) -> DoubleValue.of(Double.parseDouble(s)));
-            put("google.protobuf.FloatValue", (s) -> FloatValue.of(Float.parseFloat(s)));
-            put("google.protobuf.Int64Value", (s) -> Int64Value.of(Long.parseLong(s)));
-            put("google.protobuf.UInt64Value", (s) -> UInt64Value.of(Long.parseLong(s)));
-            put("google.protobuf.Int32Value", (s) -> Int32Value.of(Integer.parseInt(s)));
-            put("google.protobuf.UInt32Value", (s) -> UInt32Value.of(Integer.parseInt(s)));
-            put("google.protobuf.BoolValue", (s) -> BoolValue.of(Boolean.parseBoolean(s)));
-            put("google.protobuf.StringValue", StringValue::of);
-            put("google.protobuf.BytesValue", (s) -> BytesValue.of(ByteString.copyFrom(s.getBytes())));
+            put(DoubleValue.getDescriptor(), (s) -> DoubleValue.of(Double.parseDouble(s)));
+            put(FloatValue.getDescriptor(), (s) -> FloatValue.of(Float.parseFloat(s)));
+            put(Int64Value.getDescriptor(), (s) -> Int64Value.of(Long.parseLong(s)));
+            put(UInt64Value.getDescriptor(), (s) -> UInt64Value.of(Long.parseLong(s)));
+            put(Int32Value.getDescriptor(), (s) -> Int32Value.of(Integer.parseInt(s)));
+            put(UInt32Value.getDescriptor(), (s) -> UInt32Value.of(Integer.parseInt(s)));
+            put(BoolValue.getDescriptor(), (s) -> BoolValue.of(Boolean.parseBoolean(s)));
+            put(StringValue.getDescriptor(), StringValue::of);
+            put(BytesValue.getDescriptor(), (s) -> BytesValue.of(ByteString.copyFrom(s.getBytes())));
         }
     };
 
@@ -103,9 +104,8 @@ public final class Variable {
             case ENUM:
                 return field.getEnumType().findValueByName(value);
             case MESSAGE:
-                String name = field.getMessageType().getFullName();
-                if (wrappers.containsKey(name)) {
-                    return wrappers.get(name).apply(value);
+                if (wrappers.containsKey(field.getMessageType())) {
+                    return wrappers.get(field.getMessageType()).apply(value);
                 }
             default:
                 throw new IllegalStateException("Unsupported field type found: " + field);

--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -75,7 +75,7 @@ public class ProtoDescriptorTraverser {
             throw new IllegalArgumentException("Groups are not supported");
         }
 
-        if (field.getJavaType() == JavaType.MESSAGE) {
+        if (field.getJavaType() == JavaType.MESSAGE && !SimpleFieldType.isWrapper(field)) {
             onMessageField(field);
         } else {
             visitor.onSimpleField(field, SimpleFieldType.fromDescriptor(field));

--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -75,7 +75,7 @@ public class ProtoDescriptorTraverser {
             throw new IllegalArgumentException("Groups are not supported");
         }
 
-        if (field.getJavaType() == JavaType.MESSAGE && !SimpleFieldType.isWrapper(field)) {
+        if (field.getJavaType() == JavaType.MESSAGE && !SimpleFieldMapper.isSupported(field)) {
             onMessageField(field);
         } else {
             visitor.onSimpleField(field, SimpleFieldType.fromDescriptor(field));

--- a/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
@@ -92,8 +92,8 @@ public abstract class ProtoVisitor {
                     return SimpleFieldType.ENUM;
 
                 case MESSAGE:
-                    if (isWrapper(field)) {
-                        return wrappers.get(field.getMessageType());
+                    if (SimpleFieldMapper.isSupported(field)) {
+                        return SimpleFieldMapper.forDescriptor(field).getType();
                     }
                 case GROUP:
                 default:

--- a/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
@@ -11,6 +11,12 @@ public abstract class ProtoVisitor {
     public enum SimpleFieldType {
         INT, LONG, BOOL, DOUBLE, FLOAT, STRING, BYTES, ENUM;
 
+        /**
+         * Maps supported wrapper types to a {@link SimpleFieldType}.
+         *
+         * There's no simple way to identify whether the message is a wrapper, we have to use
+         * explicit full names.
+         */
         static Map<String, SimpleFieldType> wrappers = new HashMap<String, SimpleFieldType>() {
             {
                 put("google.protobuf.DoubleValue", DOUBLE);
@@ -25,6 +31,12 @@ public abstract class ProtoVisitor {
             }
         };
 
+        /**
+         * Checks whether the supplied {@link FieldDescriptor} represents a supported wrapper type.
+         *
+         * @param field field descriptor
+         * @return whether the field is a supported wrapper type
+         */
         public static boolean isWrapper(FieldDescriptor field) {
             return wrappers.containsKey(field.getMessageType().getFullName());
         }

--- a/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
@@ -1,6 +1,16 @@
 package grpcbridge.util;
 
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,19 +25,19 @@ public abstract class ProtoVisitor {
          * Maps supported wrapper types to a {@link SimpleFieldType}.
          *
          * There's no simple way to identify whether the message is a wrapper, we have to use
-         * explicit full names.
+         * explicit descriptors matching.
          */
-        static Map<String, SimpleFieldType> wrappers = new HashMap<String, SimpleFieldType>() {
+        static Map<Descriptor, SimpleFieldType> wrappers = new HashMap<Descriptor, SimpleFieldType>() {
             {
-                put("google.protobuf.DoubleValue", DOUBLE);
-                put("google.protobuf.FloatValue", FLOAT);
-                put("google.protobuf.Int64Value", LONG);
-                put("google.protobuf.UInt64Value", LONG);
-                put("google.protobuf.Int32Value", INT);
-                put("google.protobuf.UInt32Value", INT);
-                put("google.protobuf.BoolValue", BOOL);
-                put("google.protobuf.StringValue", STRING);
-                put("google.protobuf.BytesValue", BYTES);
+                put(DoubleValue.getDescriptor(), DOUBLE);
+                put(FloatValue.getDescriptor(), FLOAT);
+                put(Int64Value.getDescriptor(), LONG);
+                put(UInt64Value.getDescriptor(), LONG);
+                put(Int32Value.getDescriptor(), INT);
+                put(UInt32Value.getDescriptor(), INT);
+                put(BoolValue.getDescriptor(), BOOL);
+                put(StringValue.getDescriptor(), STRING);
+                put(BytesValue.getDescriptor(), BYTES);
             }
         };
 
@@ -38,7 +48,7 @@ public abstract class ProtoVisitor {
          * @return whether the field is a supported wrapper type
          */
         public static boolean isWrapper(FieldDescriptor field) {
-            return wrappers.containsKey(field.getMessageType().getFullName());
+            return wrappers.containsKey(field.getMessageType());
         }
 
         /**
@@ -83,7 +93,7 @@ public abstract class ProtoVisitor {
 
                 case MESSAGE:
                     if (isWrapper(field)) {
-                        return wrappers.get(field.getMessageType().getFullName());
+                        return wrappers.get(field.getMessageType());
                     }
                 case GROUP:
                 default:

--- a/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
@@ -1,55 +1,12 @@
 package grpcbridge.util;
 
-import com.google.protobuf.BoolValue;
-import com.google.protobuf.BytesValue;
-import com.google.protobuf.Descriptors.Descriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.google.protobuf.DoubleValue;
-import com.google.protobuf.FloatValue;
-import com.google.protobuf.Int32Value;
-import com.google.protobuf.Int64Value;
-import com.google.protobuf.StringValue;
-import com.google.protobuf.UInt32Value;
-import com.google.protobuf.UInt64Value;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import static java.lang.String.format;
+
+import com.google.protobuf.Descriptors.FieldDescriptor;
 
 public abstract class ProtoVisitor {
     public enum SimpleFieldType {
         INT, LONG, BOOL, DOUBLE, FLOAT, STRING, BYTES, ENUM;
-
-        /**
-         * Maps supported wrapper types to a {@link SimpleFieldType}.
-         *
-         * There's no simple way to identify whether the message is a wrapper, we have to use
-         * explicit descriptors matching.
-         */
-        static Map<Descriptor, SimpleFieldType> wrappers = new HashMap<Descriptor, SimpleFieldType>() {
-            {
-                put(DoubleValue.getDescriptor(), DOUBLE);
-                put(FloatValue.getDescriptor(), FLOAT);
-                put(Int64Value.getDescriptor(), LONG);
-                put(UInt64Value.getDescriptor(), LONG);
-                put(Int32Value.getDescriptor(), INT);
-                put(UInt32Value.getDescriptor(), INT);
-                put(BoolValue.getDescriptor(), BOOL);
-                put(StringValue.getDescriptor(), STRING);
-                put(BytesValue.getDescriptor(), BYTES);
-            }
-        };
-
-        /**
-         * Checks whether the supplied {@link FieldDescriptor} represents a supported wrapper type.
-         *
-         * @param field field descriptor
-         * @return whether the field is a supported wrapper type
-         */
-        public static boolean isWrapper(FieldDescriptor field) {
-            return wrappers.containsKey(field.getMessageType());
-        }
 
         /**
          * Maps simple protobuf types to a {@link SimpleFieldType}.

--- a/lib/src/main/java/grpcbridge/util/SimpleFieldMapper.java
+++ b/lib/src/main/java/grpcbridge/util/SimpleFieldMapper.java
@@ -1,0 +1,96 @@
+package grpcbridge.util;
+
+
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import grpcbridge.util.ProtoVisitor.SimpleFieldType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.BOOL;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.BYTES;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.DOUBLE;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.FLOAT;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.INT;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.LONG;
+import static grpcbridge.util.ProtoVisitor.SimpleFieldType.STRING;
+
+/**
+ * Contains mapping for protobuf wrappers, with matching {@link SimpleFieldType} and a value parser function.
+ */
+public class SimpleFieldMapper {
+    private final SimpleFieldType type;
+    private final Function<String, Object> parser;
+
+    private SimpleFieldMapper(SimpleFieldType type, Function<String, Object> parser) {
+        this.type = type;
+        this.parser = parser;
+    }
+
+    /**
+     * Maps supported wrapper types to a {@link SimpleFieldMapper}.
+     *
+     * There's no simple way to identify whether the message is a wrapper, we have to use
+     * explicit descriptors matching.
+     */
+    private static final Map<Descriptor, SimpleFieldMapper> mappers = new HashMap<Descriptor, SimpleFieldMapper>() {
+        {
+            put(DoubleValue.getDescriptor(), new SimpleFieldMapper(DOUBLE, (s) -> DoubleValue.of(Double.parseDouble(s))));
+            put(FloatValue.getDescriptor(), new SimpleFieldMapper(FLOAT, (s) -> FloatValue.of(Float.parseFloat(s))));
+            put(Int64Value.getDescriptor(), new SimpleFieldMapper(LONG, (s) -> Int64Value.of(Long.parseLong(s))));
+            put(UInt64Value.getDescriptor(), new SimpleFieldMapper(LONG, (s) -> UInt64Value.of(Long.parseLong(s))));
+            put(Int32Value.getDescriptor(), new SimpleFieldMapper(INT, (s) -> Int32Value.of(Integer.parseInt(s))));
+            put(UInt32Value.getDescriptor(), new SimpleFieldMapper(INT, (s) -> UInt32Value.of(Integer.parseInt(s))));
+            put(BoolValue.getDescriptor(), new SimpleFieldMapper(BOOL, (s) -> BoolValue.of(Boolean.parseBoolean(s))));
+            put(StringValue.getDescriptor(), new SimpleFieldMapper(STRING, StringValue::of));
+            put(BytesValue.getDescriptor(), new SimpleFieldMapper(BYTES, (s) -> BytesValue.of(ByteString.copyFrom(s.getBytes()))));
+        }
+    };
+
+    /**
+     * {@link SimpleFieldType} assigned to the mapper.
+     */
+    public SimpleFieldType getType() {
+        return type;
+    }
+
+    /**
+     * Checks whether the supplied {@link FieldDescriptor} represents a supported wrapper type.
+     *
+     * @param field field descriptor
+     * @return whether the field is a supported wrapper type
+     */
+    public static boolean isSupported(FieldDescriptor field) {
+        return mappers.containsKey(field.getMessageType());
+    }
+
+    /**
+     * Returns a {@link SimpleFieldMapper} for a given ${@link FieldDescriptor}.
+     * @param field field descriptor
+     * @return matching field mapper or null if not found
+     */
+    public static SimpleFieldMapper forDescriptor(FieldDescriptor field) {
+        return mappers.get(field.getMessageType());
+    }
+
+    /**
+     * Applies value parser function to an argument.
+     * @param value input value to map
+     * @return field value
+     */
+    public Object parse(String value) {
+        return parser.apply(value);
+    }
+}

--- a/lib/src/main/java/grpcbridge/util/SimpleFieldMapper.java
+++ b/lib/src/main/java/grpcbridge/util/SimpleFieldMapper.java
@@ -1,6 +1,5 @@
 package grpcbridge.util;
 
-
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -18,8 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.base.Charsets;
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import com.google.protobuf.StringValue;
 import grpcbridge.Exceptions.ParsingException;
 import grpcbridge.Exceptions.RouteNotFoundException;
 import grpcbridge.common.TestService;
@@ -37,6 +39,8 @@ import grpcbridge.test.proto.Test.PatchRequest;
 import grpcbridge.test.proto.Test.PatchResponse;
 import grpcbridge.test.proto.Test.PostRequest;
 import grpcbridge.test.proto.Test.PostResponse;
+import grpcbridge.test.proto.Test.PostWrappersRequest;
+import grpcbridge.test.proto.Test.PostWrappersResponse;
 import grpcbridge.test.proto.Test.PutRequest;
 import grpcbridge.test.proto.Test.PutResponse;
 import io.grpc.Metadata;
@@ -90,6 +94,24 @@ public class BridgeTest implements ProtoParseTest {
         assertThat(rpcResponse).isEqualTo(responseFor(GetRequest.newBuilder()
                 .setStringField("hello")
                 .build()));
+    }
+
+    @Test
+    public void post_withWrappers() {
+        PostWrappersRequest rpcRequest = PostWrappersRequest.newBuilder()
+                .setBoolValueField(BoolValue.of(true))
+                .setStringValueField(StringValue.of("world"))
+                .build();
+
+        HttpRequest request = HttpRequest
+                .builder(POST, "/post-wrappers")
+                .body(serialize(rpcRequest))
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        PostWrappersResponse rpcResponse = parse(response.getBody(), PostWrappersResponse.newBuilder());
+
+        assertThat(rpcResponse).isEqualTo(responseFor(rpcRequest));
     }
 
     @Test

--- a/lib/src/test/java/grpcbridge/BridgeTest.java
+++ b/lib/src/test/java/grpcbridge/BridgeTest.java
@@ -117,7 +117,7 @@ public class BridgeTest implements ProtoParseTest {
     @Test
     public void get_withParams() {
         HttpRequest request = HttpRequest
-                .builder(GET, "/get?string_field=hello&int_field=987")
+                .builder(GET, "/get?string_field=hello&int_field=987&string_value_field=world")
                 .build();
 
         HttpResponse response = bridge.handle(request);
@@ -125,6 +125,7 @@ public class BridgeTest implements ProtoParseTest {
 
         assertThat(rpcResponse).isEqualTo(responseFor(GetRequest.newBuilder()
                 .setStringField("hello")
+                .setStringValueField(StringValue.of("world"))
                 .setIntField(987)
                 .build()));
     }

--- a/lib/src/test/java/grpcbridge/common/TestFactory.java
+++ b/lib/src/test/java/grpcbridge/common/TestFactory.java
@@ -38,6 +38,38 @@ public final class TestFactory {
                 .build();
     }
 
+    public static PostWrappersResponse responseFor(PostWrappersRequest request) {
+        PostWrappersResponse.Builder builder = PostWrappersResponse.newBuilder();
+        if (request.hasBoolValueField()) {
+            builder.setBoolValueField(request.getBoolValueField());
+        }
+        if (request.hasBytesValueField()) {
+            builder.setBytesValueField(request.getBytesValueField());
+        }
+        if (request.hasDoubleValueField()) {
+            builder.setDoubleValueField(request.getDoubleValueField());
+        }
+        if (request.hasFloatValueField()) {
+            builder.setFloatValueField(request.getFloatValueField());
+        }
+        if (request.hasStringValueField()) {
+            builder.setStringValueField(request.getStringValueField());
+        }
+        if (request.hasInt64ValueField()) {
+            builder.setInt64ValueField(request.getInt64ValueField());
+        }
+        if (request.hasUint64ValueField()) {
+            builder.setUint64ValueField(request.getUint64ValueField());
+        }
+        if (request.hasInt32ValueField()) {
+            builder.setInt32ValueField(request.getInt32ValueField());
+        }
+        if (request.hasUint32ValueField()) {
+            builder.setUint32ValueField(request.getUint32ValueField());
+        }
+        return builder.build();
+    }
+
     public static PostRequest newPostRequest() {
         return PostRequest.newBuilder()
                 .setIntField(123)

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -54,8 +54,9 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
     }
 
     @Override
-    public void postWrappers(PostWrappersRequest request,
-                             StreamObserver<PostWrappersResponse> responseObserver) {
+    public void postWrappers(
+            PostWrappersRequest request,
+            StreamObserver<PostWrappersResponse> responseObserver) {
         responseObserver.onNext(PostWrappersResponse.newBuilder()
                 .setStringValueField(request.getStringValueField())
                 .setBoolValueField(request.getBoolValueField())

--- a/lib/src/test/java/grpcbridge/common/TestService.java
+++ b/lib/src/test/java/grpcbridge/common/TestService.java
@@ -14,6 +14,8 @@ import grpcbridge.test.proto.Test.PatchRequest;
 import grpcbridge.test.proto.Test.PatchResponse;
 import grpcbridge.test.proto.Test.PostRequest;
 import grpcbridge.test.proto.Test.PostResponse;
+import grpcbridge.test.proto.Test.PostWrappersRequest;
+import grpcbridge.test.proto.Test.PostWrappersResponse;
 import grpcbridge.test.proto.Test.PutRequest;
 import grpcbridge.test.proto.Test.PutResponse;
 import grpcbridge.test.proto.TestServiceGrpc;
@@ -47,6 +49,16 @@ public final class TestService extends TestServiceGrpc.TestServiceImplBase {
                 .setNested(request.getNested())
                 .addAllRepeatedField(request.getRepeatedFieldList())
                 .setDefault(request.getDefault())
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void postWrappers(PostWrappersRequest request,
+                             StreamObserver<PostWrappersResponse> responseObserver) {
+        responseObserver.onNext(PostWrappersResponse.newBuilder()
+                .setStringValueField(request.getStringValueField())
+                .setBoolValueField(request.getBoolValueField())
                 .build());
         responseObserver.onCompleted();
     }

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package grpcbridge.test.proto;
 
 import "google/api/annotations.proto";
+import "google/protobuf/wrappers.proto";
 import "grpcbridge/grpcbridge-options.proto";
 
 enum Enum { INVALID = 0; VALID = 1; }
@@ -46,6 +47,30 @@ message GetResponse {
   repeated string repeated_field = 10;
   DefaultMessage default = 11;
   DefaultMessage unset_default = 12;
+}
+
+message PostWrappersRequest {
+  google.protobuf.DoubleValue double_value_field = 1;
+  google.protobuf.FloatValue float_value_field = 2;
+  google.protobuf.Int64Value int64_value_field = 3;
+  google.protobuf.UInt64Value uint64_value_field = 4;
+  google.protobuf.Int32Value int32_value_field = 5;
+  google.protobuf.UInt32Value uint32_value_field = 6;
+  google.protobuf.BoolValue bool_value_field = 7;
+  google.protobuf.StringValue string_value_field = 8;
+  google.protobuf.BytesValue bytes_value_field = 9;
+}
+
+message PostWrappersResponse {
+  google.protobuf.DoubleValue double_value_field = 1;
+  google.protobuf.FloatValue float_value_field = 2;
+  google.protobuf.Int64Value int64_value_field = 3;
+  google.protobuf.UInt64Value uint64_value_field = 4;
+  google.protobuf.Int32Value int32_value_field = 5;
+  google.protobuf.UInt32Value uint32_value_field = 6;
+  google.protobuf.BoolValue bool_value_field = 7;
+  google.protobuf.StringValue string_value_field = 8;
+  google.protobuf.BytesValue bytes_value_field = 9;
 }
 
 message PostRequest {
@@ -94,6 +119,13 @@ service TestService {
   rpc Get (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
         get: "/get/{string_field}"
+    };
+  }
+
+  rpc PostWrappers (PostWrappersRequest) returns (PostWrappersResponse) {
+    option (google.api.http) = {
+      post: "/post-wrappers"
+      body: "*"
     };
   }
 

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -32,6 +32,7 @@ message GetRequest {
   Nested nested = 9;
   repeated string repeated_field = 10;
   DefaultMessage default = 11;
+  google.protobuf.StringValue string_value_field = 12;
 }
 
 message GetResponse {
@@ -47,6 +48,7 @@ message GetResponse {
   repeated string repeated_field = 10;
   DefaultMessage default = 11;
   DefaultMessage unset_default = 12;
+  google.protobuf.StringValue string_value_field = 13;
 }
 
 message PostWrappersRequest {

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -4,6 +4,7 @@ package grpcbridge.test.proto;
 import "included-test-file.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
 import "grpcbridge/grpcbridge-options.proto";
 import "openapi_v2.proto";
 
@@ -72,6 +73,30 @@ message GetResponse {
   }
 
   string excluded = 19 [deprecated = true];
+}
+
+message GetWrappersRequest {
+  google.protobuf.DoubleValue double_value_field = 1;
+  google.protobuf.FloatValue float_value_field = 2;
+  google.protobuf.Int64Value int64_value_field = 3;
+  google.protobuf.UInt64Value uint64_value_field = 4;
+  google.protobuf.Int32Value int32_value_field = 5;
+  google.protobuf.UInt32Value uint32_value_field = 6;
+  google.protobuf.BoolValue bool_value_field = 7;
+  google.protobuf.StringValue string_value_field = 8;
+  google.protobuf.BytesValue bytes_value_field = 9;
+}
+
+message GetWrappersResponse {
+  google.protobuf.DoubleValue double_value_field = 1;
+  google.protobuf.FloatValue float_value_field = 2;
+  google.protobuf.Int64Value int64_value_field = 3;
+  google.protobuf.UInt64Value uint64_value_field = 4;
+  google.protobuf.Int32Value int32_value_field = 5;
+  google.protobuf.UInt32Value uint32_value_field = 6;
+  google.protobuf.BoolValue bool_value_field = 7;
+  google.protobuf.StringValue string_value_field = 8;
+  google.protobuf.BytesValue bytes_value_field = 9;
 }
 
 message Excluded {
@@ -153,6 +178,12 @@ service TestService {
   rpc GetNestedParams (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
         get: "/get-nested/{nested.nested_field}"
+    };
+  }
+
+  rpc GetWrappers (GetWrappersRequest) returns (GetWrappersResponse) {
+    option (google.api.http) = {
+        get: "/get-wrappers"
     };
   }
 

--- a/swagger/src/test/resources/test-proto-swagger-camel.json
+++ b/swagger/src/test/resources/test-proto-swagger-camel.json
@@ -389,6 +389,84 @@
         "tags": []
       }
     },
+    "/get-wrappers": {
+      "get": {
+        "operationId": "TestService.GetWrappers",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.GetWrappersResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "format": "double",
+            "name": "doubleValueField",
+            "in": "query",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "format": "float",
+            "name": "floatValueField",
+            "in": "query",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "format": "string",
+            "name": "int64ValueField",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "string",
+            "name": "uint64ValueField",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "int32",
+            "name": "int32ValueField",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "format": "int32",
+            "name": "uint32ValueField",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "format": "boolean",
+            "name": "boolValueField",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "stringValueField",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "byte",
+            "name": "bytesValueField",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": []
+      }
+    },
     "/get/{stringField}": {
       "get": {
         "operationId": "TestService.Get",
@@ -773,6 +851,46 @@
       "properties": {},
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.GetWrappersResponse": {
+      "type": "object",
+      "properties": {
+        "boolValueField": {
+          "format": "boolean",
+          "type": "boolean"
+        },
+        "bytesValueField": {
+          "format": "byte",
+          "type": "string"
+        },
+        "doubleValueField": {
+          "format": "double",
+          "type": "number"
+        },
+        "floatValueField": {
+          "format": "float",
+          "type": "number"
+        },
+        "int32ValueField": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "int64ValueField": {
+          "format": "string",
+          "type": "string"
+        },
+        "stringValueField": {
+          "type": "string"
+        },
+        "uint32ValueField": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "uint64ValueField": {
+          "format": "string",
+          "type": "string"
+        }
       }
     },
     "grpcbridge.test.proto.MapNested": {

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -389,6 +389,84 @@
         "tags": []
       }
     },
+    "/get-wrappers": {
+      "get": {
+        "operationId": "TestService.GetWrappers",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.GetWrappersResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "format": "double",
+            "name": "double_value_field",
+            "in": "query",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "format": "float",
+            "name": "float_value_field",
+            "in": "query",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "format": "string",
+            "name": "int64_value_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "string",
+            "name": "uint64_value_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "int32",
+            "name": "int32_value_field",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "format": "int32",
+            "name": "uint32_value_field",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "format": "boolean",
+            "name": "bool_value_field",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "string_value_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "format": "byte",
+            "name": "bytes_value_field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": []
+      }
+    },
     "/get/{string_field}": {
       "get": {
         "operationId": "TestService.Get",
@@ -773,6 +851,46 @@
       "properties": {},
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.GetWrappersResponse": {
+      "type": "object",
+      "properties": {
+        "bool_value_field": {
+          "format": "boolean",
+          "type": "boolean"
+        },
+        "bytes_value_field": {
+          "format": "byte",
+          "type": "string"
+        },
+        "double_value_field": {
+          "format": "double",
+          "type": "number"
+        },
+        "float_value_field": {
+          "format": "float",
+          "type": "number"
+        },
+        "int32_value_field": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "int64_value_field": {
+          "format": "string",
+          "type": "string"
+        },
+        "string_value_field": {
+          "type": "string"
+        },
+        "uint32_value_field": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "uint64_value_field": {
+          "format": "string",
+          "type": "string"
+        }
       }
     },
     "grpcbridge.test.proto.MapNested": {


### PR DESCRIPTION
Even though wrappers for known types are defined as messages, they are serialized as primitives. This PR adds a support for wrappers to handle they way they are serialized.
- swagger now reports them as non-required primitives
- parameter parser converts primitives into a message for wrapper types