### PR TITLE
Naive handling of self-referencing messages

### DIFF
--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -90,6 +90,9 @@ public class ProtoDescriptorTraverser {
     private void onMessageField(FieldDescriptor field) {
         visitor.onMessageStart(field);
         field.getMessageType().getFields().forEach(fieldDescriptor -> {
+            // A naive detection of self-referencing messages.
+            // This only works for trivial cycles (foo->foo),
+            // but not for longer ones (e.g. foo->bar->foo).
             final boolean messageReferencesItself =
                     field.getContainingType() == fieldDescriptor.getContainingType();
             if (messageReferencesItself) return;

--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -90,6 +90,9 @@ public class ProtoDescriptorTraverser {
     private void onMessageField(FieldDescriptor field) {
         visitor.onMessageStart(field);
         field.getMessageType().getFields().forEach(fieldDescriptor -> {
+            final boolean messageReferencesItself =
+                    field.getContainingType() == fieldDescriptor.getContainingType();
+            if (messageReferencesItself) return;
             visitor.onBeforeField(fieldDescriptor);
             onField(fieldDescriptor);
             visitor.onAfterField(fieldDescriptor);

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -8,7 +8,7 @@ import "google/protobuf/wrappers.proto";
 import "grpcbridge/grpcbridge-options.proto";
 import "openapi_v2.proto";
 
-enum Enum {INVALID = 0; VALID = 1;}
+enum Enum { INVALID = 0; VALID = 1; }
 
 extend google.protobuf.FieldOptions {
   bool test_required = 50000;
@@ -26,6 +26,12 @@ message MapNested {
   string string_field = 1;
   map<string, Nested> map_field = 2;
 }
+
+message SelfReferencing {
+  string foo = 1;
+  repeated SelfReferencing circular = 2;
+}
+
 message GetRequest {
   string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
@@ -113,7 +119,7 @@ message PostRequest {
 
 message PostCircularRequest {
   string string_field = 1 [(test_required) = true];
-  repeated PostCircularRequest circular = 2;
+  SelfReferencing circular = 2;
 }
 
 message PostResponse {

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -8,7 +8,7 @@ import "google/protobuf/wrappers.proto";
 import "grpcbridge/grpcbridge-options.proto";
 import "openapi_v2.proto";
 
-enum Enum { INVALID = 0; VALID = 1; }
+enum Enum {INVALID = 0; VALID = 1;}
 
 extend google.protobuf.FieldOptions {
   bool test_required = 50000;
@@ -26,7 +26,6 @@ message MapNested {
   string string_field = 1;
   map<string, Nested> map_field = 2;
 }
-
 message GetRequest {
   string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
@@ -112,6 +111,11 @@ message PostRequest {
   string excluded = 3 [deprecated = true];
 }
 
+message PostCircularRequest {
+  string string_field = 1 [(test_required) = true];
+  repeated PostCircularRequest circular = 2;
+}
+
 message PostResponse {
   string string_field = 1;
   int32 int_field = 2;
@@ -160,84 +164,91 @@ message PatchResponse {
 service TestService {
   rpc Get (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-        get: "/get/{string_field}"
+      get: "/get/{string_field}"
     };
   }
 
   rpc GetStatic (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-        get: "/get-static"
+      get: "/get-static"
     };
   }
 
   rpc GetMultipleParams (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-        get: "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}"
+      get: "/get-multi/{string_field}/{int_field}/{long_field}/{float_field}/{double_field}/{bool_field}/{bytes_field}/{enum_field}"
     };
   }
 
   rpc GetNestedParams (GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-        get: "/get-nested/{nested.nested_field}"
+      get: "/get-nested/{nested.nested_field}"
     };
   }
 
   rpc GetWrappers (GetWrappersRequest) returns (GetWrappersResponse) {
     option (google.api.http) = {
-        get: "/get-wrappers"
+      get: "/get-wrappers"
     };
   }
 
   rpc Post (PostRequest) returns (PostResponse) {
     option (google.api.http) = {
-        post: "/post/{string_field}"
-        body: "*"
+      post: "/post/{string_field}"
+      body: "*"
+    };
+  }
+
+  rpc PostCircular (PostCircularRequest) returns (PostResponse) {
+    option (google.api.http) = {
+      post: "/post-circular/{string_field}"
+      body: "*"
     };
   }
 
   rpc PostBody (PostBodyRequest) returns (PostBodyResponse) {
     option (google.api.http) = {
-        post: "/post-body"
-        body: "*"
+      post: "/post-body"
+      body: "*"
     };
   }
 
   rpc PostNoBody (PostRequest) returns (PostResponse) {
     option (google.api.http) = {
-        post: "/post-no-body/{int_field}"
+      post: "/post-no-body/{int_field}"
     };
   }
 
   rpc PostCustomBody (PostRequest) returns (PostResponse) {
     option (google.api.http) = {
-        post: "/post-custom/{string_field}"
-        body: "{int_field}"
+      post: "/post-custom/{string_field}"
+      body: "{int_field}"
     };
   }
 
   rpc Put (PutRequest) returns (PutResponse) {
     option (google.api.http) = {
-        put: "/put/{string_field}"
-        body: "*"
+      put: "/put/{string_field}"
+      body: "*"
     };
   }
 
   rpc Delete (DeleteRequest) returns (DeleteResponse) {
     option (google.api.http) = {
-        delete: "/delete/{string_field}"
+      delete: "/delete/{string_field}"
     };
   }
 
   rpc Patch (PatchRequest) returns (PatchResponse) {
     option (google.api.http) = {
-        patch: "/patch/{string_field}"
+      patch: "/patch/{string_field}"
     };
   }
 
   rpc Excluded (GetRequest) returns (GetRequest) {
     option (grpcbridge.swagger.exclude) = true;
     option (google.api.http) = {
-        get: "/excluded/{string_field}"
+      get: "/excluded/{string_field}"
     };
   }
 

--- a/swagger/src/test/resources/test-proto-swagger-camel.json
+++ b/swagger/src/test/resources/test-proto-swagger-camel.json
@@ -660,6 +660,36 @@
         "tags": []
       }
     },
+    "/post-circular/{stringField}": {
+      "post": {
+        "operationId": "TestService.PostCircular",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "stringField",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
+    },
     "/post-custom/{stringField}": {
       "post": {
         "operationId": "TestService.PostCustomBody",
@@ -1001,6 +1031,17 @@
       "properties": {},
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.PostCircularRequest": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+          },
+          "type": "array"
+        }
       }
     },
     "grpcbridge.test.proto.PostRequest": {

--- a/swagger/src/test/resources/test-proto-swagger-camel.json
+++ b/swagger/src/test/resources/test-proto-swagger-camel.json
@@ -1037,10 +1037,7 @@
       "type": "object",
       "properties": {
         "circular": {
-          "items": {
-            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
-          },
-          "type": "array"
+          "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
         }
       }
     },
@@ -1094,6 +1091,20 @@
       "type": "object",
       "properties": {
         "repeatedNestedField": {
+          "type": "string"
+        }
+      }
+    },
+    "grpcbridge.test.proto.SelfReferencing": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
+          },
+          "type": "array"
+        },
+        "foo": {
           "type": "string"
         }
       }

--- a/swagger/src/test/resources/test-proto-swagger-exclude-deprecated.json
+++ b/swagger/src/test/resources/test-proto-swagger-exclude-deprecated.json
@@ -660,6 +660,36 @@
         "tags": []
       }
     },
+    "/post-circular/{string_field}": {
+      "post": {
+        "operationId": "TestService.PostCircular",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
+    },
     "/post-custom/{string_field}": {
       "post": {
         "operationId": "TestService.PostCustomBody",
@@ -1001,6 +1031,17 @@
       "properties": {},
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.PostCircularRequest": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+          },
+          "type": "array"
+        }
       }
     },
     "grpcbridge.test.proto.PostRequest": {

--- a/swagger/src/test/resources/test-proto-swagger-exclude-deprecated.json
+++ b/swagger/src/test/resources/test-proto-swagger-exclude-deprecated.json
@@ -1037,10 +1037,7 @@
       "type": "object",
       "properties": {
         "circular": {
-          "items": {
-            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
-          },
-          "type": "array"
+          "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
         }
       }
     },
@@ -1094,6 +1091,20 @@
       "type": "object",
       "properties": {
         "repeated_nested_field": {
+          "type": "string"
+        }
+      }
+    },
+    "grpcbridge.test.proto.SelfReferencing": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
+          },
+          "type": "array"
+        },
+        "foo": {
           "type": "string"
         }
       }

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -708,6 +708,36 @@
         "tags": []
       }
     },
+    "/post-circular/{string_field}": {
+      "post": {
+        "operationId": "TestService.PostCircular",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "string_field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "schema": {
+              "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+            },
+            "name": "body",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "tags": []
+      }
+    },
     "/post-custom/{string_field}": {
       "post": {
         "operationId": "TestService.PostCustomBody",
@@ -1078,6 +1108,17 @@
       "properties": {},
       "additionalProperties": {
         "$ref": "#/definitions/grpcbridge.test.proto.MapNested"
+      }
+    },
+    "grpcbridge.test.proto.PostCircularRequest": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
+          },
+          "type": "array"
+        }
       }
     },
     "grpcbridge.test.proto.PostRequest": {

--- a/swagger/src/test/resources/test-proto-swagger.json
+++ b/swagger/src/test/resources/test-proto-swagger.json
@@ -1114,10 +1114,7 @@
       "type": "object",
       "properties": {
         "circular": {
-          "items": {
-            "$ref": "#/definitions/grpcbridge.test.proto.PostCircularRequest"
-          },
-          "type": "array"
+          "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
         }
       }
     },
@@ -1174,6 +1171,20 @@
       "type": "object",
       "properties": {
         "repeated_nested_field": {
+          "type": "string"
+        }
+      }
+    },
+    "grpcbridge.test.proto.SelfReferencing": {
+      "type": "object",
+      "properties": {
+        "circular": {
+          "items": {
+            "$ref": "#/definitions/grpcbridge.test.proto.SelfReferencing"
+          },
+          "type": "array"
+        },
+        "foo": {
           "type": "string"
         }
       }


### PR DESCRIPTION
Manifest generation fails with a `StackOverflowError` when there is a circular reference in the messages. This is an attempt to solve it for the most basic case when a message references itself.