### PR TITLE
Ignores methods without HTTP annotations

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,7 +2,3 @@ repositories {
     mavenLocal()
     maven { url "https://plugins.gradle.org/m2/" }
 }
-
-dependencies {
-    implementation "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
-}

--- a/lib/src/main/java/grpcbridge/BridgeBuilder.java
+++ b/lib/src/main/java/grpcbridge/BridgeBuilder.java
@@ -101,10 +101,9 @@ public final class BridgeBuilder {
                 service = ServerInterceptors.intercept(service, interceptors);
             }
             for (ServerMethodDefinition<?, ?> method : service.getMethods()) {
-                Route route = files.routeFor(
-                        service,
-                        (ServerMethodDefinition<Message, Message>) method);
-                routes.add(route);
+                files
+                        .routeFor(service, (ServerMethodDefinition<Message, Message>) method)
+                        .ifPresent(routes::add);
             }
         }
 

--- a/lib/src/test/java/grpcbridge/util/FileDescriptorsTest.java
+++ b/lib/src/test/java/grpcbridge/util/FileDescriptorsTest.java
@@ -1,0 +1,27 @@
+package grpcbridge.util;
+
+import com.google.protobuf.Message;
+import grpcbridge.common.TestService;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileDescriptorsTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    public void noHttp() {
+        FileDescriptors fileDescriptors = new FileDescriptors();
+        fileDescriptors.addFile(grpcbridge.test.proto.Test.getDescriptor());
+
+        ServerServiceDefinition service = new TestService().bindService();
+        ServerMethodDefinition<?, ?> method = service
+                .getMethods()
+                .stream()
+                .filter(m -> m.getMethodDescriptor().getBareMethodName().equals("NoHttpMethod"))
+                .findFirst()
+                .get();
+        assertThat(fileDescriptors.routeFor(service, (ServerMethodDefinition<Message, Message>) method)).isEmpty();
+    }
+}

--- a/lib/src/test/proto/test.proto
+++ b/lib/src/test/proto/test.proto
@@ -230,4 +230,6 @@ service TestService {
         get: "/get-stream/{string_field}"
     };
   }
+
+  rpc NoHttpMethod (GetRequest) returns (GetResponse);
 }

--- a/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
+++ b/swagger/src/main/java/grpcbridge/swagger/BridgeSwaggerManifestGenerator.java
@@ -71,6 +71,9 @@ public final class BridgeSwaggerManifestGenerator implements SwaggerManifestGene
     }
 
     private void applyMethodDescriptor(SwaggerSchema schema, MethodDescriptor descriptor) {
+        if (!descriptor.getOptions().hasExtension(AnnotationsProto.http)) {
+            return;
+        }
         BridgeHttpRule rule = BridgeHttpRule.create(
                 descriptor.getOptions().getExtension(AnnotationsProto.http)
         );


### PR DESCRIPTION
Treats methods without HTTP annotations as if they don't exist. Today if a single service has any method without HTTP bindings, we end up throwing a ConfigurationException in scenarios where we should be throwing NotFound. The intent of the ConfigurationException was to handle the cases where the FileDescriptor was not supplied, but we can disambiguate between the two scenarios.